### PR TITLE
Make email required on signup

### DIFF
--- a/django/publicmapping/publicmapping/templates/account.html
+++ b/django/publicmapping/publicmapping/templates/account.html
@@ -37,10 +37,10 @@
                 {% endif %}/></td>
             </tr>
             <tr>
-                <td colspan="2"><span class="recommended">{% trans "An email address is recommended to recover a forgotten password" %}</span></td>
+                <td colspan="2"><span class="recommended">{% trans "An email address is required. This email will be used for password recovery." %}</span></td>
             </tr>
             <tr>
-                <td class="fname">{% trans "Email Address" %}</td>
+                <td class="fname">{% trans "Email Address" %} *</td>
                 <td><input id="email" name="email" class="field" maxlength="75"
                 {% if is_registered %}
                     value="{{ userinfo.email }}"

--- a/django/publicmapping/static/js/register.js
+++ b/django/publicmapping/static/js/register.js
@@ -135,6 +135,15 @@ $(function(){
             passwordhint.addClass('field');
             passwordhint.removeClass('error');
         }
+        if (email.val() == '') {
+            email.removeClass('field');
+            email.addClass('error');
+            return false;
+        }
+        else {
+            email.addClass('field');
+            email.removeClass('error');
+        }
         if ($.trim(email.val()) != '') {
             if (!(email.val().match(/^([\w\-\.\+])+\@([\w\-\.])+\.([A-Za-z]{2,4})$/))) {
                 email.removeClass('field');

--- a/django/publicmapping/static/js/register.js
+++ b/django/publicmapping/static/js/register.js
@@ -135,7 +135,7 @@ $(function(){
             passwordhint.addClass('field');
             passwordhint.removeClass('error');
         }
-        if (email.val() == '') {
+        if (!(email.val().match(/^([\w\-\.\+])+\@([\w\-\.])+\.([A-Za-z]{2,4})$/))) {
             email.removeClass('field');
             email.addClass('error');
             return false;
@@ -143,17 +143,6 @@ $(function(){
         else {
             email.addClass('field');
             email.removeClass('error');
-        }
-        if ($.trim(email.val()) != '') {
-            if (!(email.val().match(/^([\w\-\.\+])+\@([\w\-\.])+\.([A-Za-z]{2,4})$/))) {
-                email.removeClass('field');
-                email.addClass('error');
-                return false;
-            }
-            else {
-                email.addClass('field');
-                email.removeClass('error');
-            }            
         }
 
         if (agree.length > 0 && !agree[0].checked) {


### PR DESCRIPTION
## Overview

This makes the email input required on account sign up.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

<img width="1680" alt="screen shot 2018-04-06 at 1 13 00 pm" src="https://user-images.githubusercontent.com/3959096/38434421-4445c082-399c-11e8-93b0-8b6937b3bcc4.png">

## Testing Instructions

 * Build and serve 
 * On the home page, click "Sign Up". Make sure the email field has a * on the label, the note above is says that the email is required, and that the form will not submit without entering an email.