### PR TITLE
More various PA configuration

### DIFF
--- a/django/publicmapping/config/config.xml
+++ b/django/publicmapping/config/config.xml
@@ -74,8 +74,8 @@
 
     <Scoring>
         <ScoreFunctions>
-            <ScoreFunction id="district_schwartzberg" type="district"
-                calculator="redistricting.calculators.Schwartzberg"
+            <ScoreFunction id="district_polsbypopper" type="district"
+                calculator="redistricting.calculators.PolsbyPopper"
                 label="Compactness" user_selectable="true">
                 <LegislativeBody ref="congress"/>
             </ScoreFunction>
@@ -98,7 +98,7 @@
                 <ScoreArgument name="value1" ref="district_contiguous"/>
             </ScoreFunction>
 
-            <ScoreFunction id="plan_congress_noncontiguous" type="plan"
+            <ScoreFunction id="congress_plan_noncontiguous" type="plan"
                 calculator="redistricting.calculators.Contiguity"
                 label="Contiguous">
                 <Argument name="target" value="18" />
@@ -354,10 +354,17 @@
                 description="Contiguity means that every part of a district must be reachable from every other part without crossing the district&apos;s borders. All districts within a plan must be contiguous.">
             </ScoreFunction>
 
-            <ScoreFunction id="plan_schwartzberg" type="plan"
-                calculator="redistricting.calculators.Schwartzberg"
+            <ScoreFunction id="congress_plan_polsbypopper" type="plan"
+                calculator="redistricting.calculators.PolsbyPopper"
                 label="Average Compactness"
-                description="The competition is using the &apos;Inverse Schwartzberg&apos; compactness measure. This measure is a ratio of the circumference of the circle whose area is equal to the area of the district to the perimeter of the district." >
+                description="The competition is using the &apos;Polsby-Popper&apos; compactness measure. This measure is a ratio of the area of a circle with the same perimeter as a district to the area of the district." >
+            </ScoreFunction>
+
+            <ScoreFunction id="congress_plan_equivalence" type="plan"
+                calculator="redistricting.calculators.Equivalence"
+                label="Equal Population"
+                description="The Equipopulation score is the difference between the district with the highest population and the district with the lowest population.">
+                <SubjectArgument name="value" ref="poptot" />
             </ScoreFunction>
 
             <ScoreFunction id="district_poptot" type="district"
@@ -397,6 +404,13 @@
                 <Argument name="comptype" value="Schwartzberg" />
             </ScoreFunction>
 
+            <ScoreFunction id="report_score_compactness_pp" type="district"
+                calculator="redistricting.reportcalculators.Compactness"
+                label="Polsby-Popper" >
+                <LegislativeBody ref="congress"/>
+                <Argument name="comptype" value="PolsbyPopper" />
+            </ScoreFunction>
+
             <ScoreFunction id="report_score_compactness_ro" type="district"
                 calculator="redistricting.reportcalculators.Compactness"
                 label="Roeck" >
@@ -414,31 +428,45 @@
         <ScorePanels>
             <!-- Leaderboard -->
             <ScorePanel id="panel_compact_all" type="plan" position="1"
-                title="Schwartzberg" template="leaderboard_panel_all.html"
+                title="Compactness" template="leaderboard_panel_all.html"
                 is_ascending="false">
-                <Score ref="plan_schwartzberg" />
+                <Score ref="congress_plan_polsbypopper" />
             </ScorePanel>
 
             <ScorePanel id="panel_compact_mine" type="plan" position="1"
-                title="Schwartzberg" template="leaderboard_panel_mine.html"
+                title="Compactness" template="leaderboard_panel_mine.html"
                 is_ascending="false">
-                <Score ref="plan_schwartzberg" />
+                <Score ref="congress_plan_polsbypopper" />
+            </ScorePanel>
+
+            <ScorePanel id="panel_equivalence_all" type="plan" position="2"
+                title="Equal Population" template="leaderboard_panel_all.html"
+                is_ascending="false">
+                <Score ref="congress_plan_equivalence" />
+            </ScorePanel>
+
+            <ScorePanel id="panel_equivalence_mine" type="plan" position="2"
+                title="Equal Population" template="leaderboard_panel_mine.html"
+                is_ascending="false">
+                <Score ref="congress_plan_equivalence" />
             </ScorePanel>
 
             <!-- Summary above all sidebar panels -->
             <ScorePanel id="congressional_panel_summary" type="plan_summary" position="1"
                 title="Plan Summary" cssclass="plan_summary congressional" template="plan_summary.html">
                 <Score ref="congress_plan_equipopulation_summary"/>
-                <Score ref="plan_congress_noncontiguous"/>
+                <Score ref="congress_plan_noncontiguous"/>
+                <Score ref="congress_plan_polsbypopper"/>
+                <Score ref="congress_plan_equivalence"/>
             </ScorePanel>
 
             <!-- Basic Information -->
-            <ScorePanel id="congressional_panel_info" type="district" position="2"
+            <ScorePanel id="congressional_panel_info" type="district" position="1"
                 title="Basic Information" cssclass="district_basic_info congressional"
                 template="basic_information.html">
                 <Score ref="congressional_population" />
                 <Score ref="district_contiguous" />
-                <Score ref="district_schwartzberg" />
+                <Score ref="district_polsbypopper" />
             </ScorePanel>
 
             <!-- Community Comments -->
@@ -471,6 +499,7 @@
 
             <ScorePanel id="report_panel_compactness" type="district" position="1"
                 title="Compactness" template="report_panel.html" cssclass="reports compactness">
+                <Score ref="report_score_compactness_pp" />
                 <Score ref="report_score_compactness_sc" />
                 <Score ref="report_score_compactness_lw" />
                 <Score ref="report_score_compactness_ro" />
@@ -486,10 +515,12 @@
             <ScoreDisplay id="congress_leader_all" legislativebodyref="congress" type="leaderboard"
                 title="Congressional Leaderboard - All" cssclass="leaderboard congress">
                 <ScorePanel ref="panel_compact_all" />
+                <ScorePanel ref="panel_equivalence_all" />
             </ScoreDisplay>
             <ScoreDisplay id="congress_leader_mine" legislativebodyref="congress" type="leaderboard"
                 title="Congressional Leaderboard - Mine" cssclass="leaderboard congress">
                 <ScorePanel ref="panel_compact_mine" />
+                <ScorePanel ref="panel_equivalence_mine" />
             </ScoreDisplay>
 
              <!-- Sidebar configuration -->
@@ -541,17 +572,28 @@
     </Validation>
 
     <GeoLevels>
-      <GeoLevel id="municipality" name="municipality" label="municipality" min_zoom="0" sort_key="1" tolerance="250">
-          <Shapefile path="/data/pa_3785.shp">
+      <GeoLevel id="municipality" name="municipality" label="municipality" min_zoom="0" sort_key="1" tolerance="25">
+          <Shapefile path="/data/pa_3785_cleaned.shp">
               <Fields>
                   <Field name="NAME_WARD" type="name"/>
-                  <Field name="GEOID" type="portable"/>
+                  <Field name="NAMEWARDID" type="portable"/>
               </Fields>
           </Shapefile>
       </GeoLevel>
     </GeoLevels>
 
-    <Project sessionquota="5" sessiontimeout="15">
+    <Templates>
+        <Template name="Old Congressional">
+            <LegislativeBody ref="congress"/>
+            <Blockfile path="/data/pa-congress-old.csv" />
+        </Template>
+        <Template name="New Congressional">
+            <LegislativeBody ref="congress"/>
+            <Blockfile path="/data/pa-congress-new.csv" />
+        </Template>
+    </Templates>
+
+    <Project sessionquota="5000" sessiontimeout="15">
         <Internationalization timezone="US/Eastern" default="en">
             <Language code="en" label="English" />
             <Language code="es" label="Spanish" />
@@ -560,7 +602,7 @@
             <MapServer
                 ns="pmp"
                 nshref="https://github.com/PublicMapping/"
-                maxfeatures="100" />
+                maxfeatures="500" />
             <Upload maxsize="5300"/>
             <FixUnassigned minpercent="99" comparatorsubject="poptot" />
         </Redistricting>

--- a/django/publicmapping/redistricting/calculators.py
+++ b/django/publicmapping/redistricting/calculators.py
@@ -667,7 +667,12 @@ class PolsbyPopper(CalculatorBase):
             compactness += 4 * pi * district.geom.area / perimeter / perimeter
             num += 1
 
-        self.result = {'value': compactness / num}
+        if num == 0:
+            val = 0
+        else:
+            val = compactness / num
+
+        self.result = {'value': val}
 
     def html(self):
         """
@@ -677,7 +682,7 @@ class PolsbyPopper(CalculatorBase):
         @return: A number formatted similar to "1.00%", or "n/a"
         """
         if not self.result is None and 'value' in self.result:
-            return self.percentage()
+            return '<span>%s</span>' % self.percentage()
         else:
             return _("n/a")
 
@@ -1486,7 +1491,8 @@ class Equivalence(CalculatorBase):
         @return: A string in the format of "1,000" or "n/a" if no result.
         """
         if not self.result is None and 'value' in self.result:
-            return self.template('{{ result.value|floatformat:0 }}')
+            return self.template(
+                '<span>{{ result.value|floatformat:0 }}</span>')
 
         return _('n/a')
 

--- a/django/publicmapping/redistricting/models.py
+++ b/django/publicmapping/redistricting/models.py
@@ -3429,7 +3429,7 @@ def create_unassigned_district(sender, **kwargs):
             all_geom = joined_shape
 
         if plan.district_set.count() > 0:
-            taken = MultiPolygon(
+            taken = GeometryCollection(
                 [x.geom.unary_union for x in plan.district_set.all()])
             unassigned.geom = enforce_multi(all_geom.difference(taken))
             unassigned.simplify()  # implicit save

--- a/django/publicmapping/redistricting/models.py
+++ b/django/publicmapping/redistricting/models.py
@@ -47,7 +47,7 @@ from django.template.loader import render_to_string
 from django_comments.models import Comment
 from django.contrib.contenttypes.models import ContentType
 from django.template.defaultfilters import title
-from redistricting.calculators import Schwartzberg, Contiguity, SumValues
+from redistricting.calculators import PolsbyPopper, Contiguity, SumValues
 from tagging.models import TaggedItem, Tag
 from tagging.registry import register
 from datetime import datetime
@@ -1679,8 +1679,8 @@ class Plan(models.Model):
 
         # Grab ScoreFunctions so we can use cached scores for districts if they exist
         computed_district_score = ComputedDistrictScore()
-        schwartzberg_function = ScoreFunction.objects.get(
-            name='district_schwartzberg')
+        polsbypopper_function = ScoreFunction.objects.get(
+            name='district_polsbypopper')
         contiguity_function = ScoreFunction.objects.get(
             name='district_contiguous')
 
@@ -1692,7 +1692,7 @@ class Plan(models.Model):
 
         for district in qset:
             computed_compactness = computed_district_score.compute(
-                schwartzberg_function, district=district)
+                polsbypopper_function, district=district)
             computed_contiguity = computed_district_score.compute(
                 contiguity_function, district=district)
 

--- a/scripts/configure_pa_data
+++ b/scripts/configure_pa_data
@@ -25,7 +25,7 @@ function fetch_dev_data() {
         exec -T django \
         wget -q \
             -O /data/districtbuilder_data.zip \
-            http://s3.amazonaws.com/global-districtbuilder-data-us-east-1/pa/pa_3785.zip
+            http://s3.amazonaws.com/global-districtbuilder-data-us-east-1/pa/pa_3785_cleaned.zip
 }
 
 function recreate_database() {


### PR DESCRIPTION
## Overview

This PR is a mixed bag of configuration-related changes. See the commit messages for details.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

![db-pa-new-congressional](https://user-images.githubusercontent.com/6386/38498821-9e896dd0-3bd3-11e8-9cf0-191400f9c711.png)

## Testing Instructions

 * `ssh` into the VM and run: `scripts/configure_pa_data` (note: this will clear your DB)
 * Total load time seems to have decreased to about 5-10 minutes, so you shouldn't need to wait too long
 * Browse to the site, create a user, and create a plan from one of the two new templates
 * Verify that there are a couple new scores in the score panel (Equal Population and Average Compactness -- n.b. the screenshot above is a little old and doesn't include these)
 * There is a new leaderboard score for Equal Population as well, but it will be hard to create a valid plan. Optional, but if you'd like to see it, you can hack the `django/publicmapping/redistricting/views.py` to skip validation, by editing the `scoreplan` function and bypassing the `for criteria in criterion` loop. I've already done this, and have also bypassed each individually to ensure all desired validation is being performed.