### PR TITLE
Remove unique constraint for user email on signup

### DIFF
--- a/django/publicmapping/publicmapping/views.py
+++ b/django/publicmapping/publicmapping/views.py
@@ -131,12 +131,6 @@ def userregister(request):
                 status['message'] = 'name exists'
                 return HttpResponse(json.dumps(status))
 
-            email_exists = email != '' and User.objects.filter(
-                email__exact=email)
-            if email_exists:
-                status['message'] = 'email exists'
-                return HttpResponse(json.dumps(status))
-
             try:
                 User.objects.create_user(username, email, password)
             except Exception as error:


### PR DESCRIPTION
## Overview

Remove unique constraint of email on signup. 

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Sign up multiple times with different usernames but same emails