### PR TITLE
Fix info panel position

### DIFF
--- a/django/publicmapping/config/config.xml
+++ b/django/publicmapping/config/config.xml
@@ -461,7 +461,7 @@
             </ScorePanel>
 
             <!-- Basic Information -->
-            <ScorePanel id="congressional_panel_info" type="district" position="1"
+            <ScorePanel id="congressional_panel_info" type="district" position="2"
                 title="Basic Information" cssclass="district_basic_info congressional"
                 template="basic_information.html">
                 <Score ref="congressional_population" />


### PR DESCRIPTION
## Overview

The info panel was configured with the same position as the summary panel. Position is used to determine display order. This caused a non-deterministic bug where sometimes it was possible for the order of the two panels to be reversed.

### Checklist

- [x ] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Notes

This is a trivial fix that is hard to test due to it's non-deterministic nature. I've already applied the fix to staging and it works, so I'm just going to merge this.
