### PR TITLE
Fix translation error

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure(2) do |config|
                        "reports/",
                        "geoserver/data_dir/",
                        "django/publicmapping/publicmapping/config_settings.py",
-                       "django/publicmapping/locale/"],
+                       "django/publicmapping/locale/*/*.mo"],
       rsync__args: ["--verbose", "--archive", "--delete", "-z", "--links"]
 
   config.vm.provider :virtualbox do |vb|


### PR DESCRIPTION
## Overview

Peter and I were running into issues with .po files. This is because for us rsync wasn't adding the .po files in the `locale` directory to the VM. Rsync excluding only .mo files fixes this. It also enables the modified .po files to be written back to the host with rsync back. 

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * `vagrant destroy`
 * `vagrant up`
 * `vagrant ssh`
 * `./scripts/update`
 * `./scripts/configure_pa_data`
 * `./scripts/server`
 * Play with the app and see it it works
