### PR TITLE
Capture DTL contest details

### DIFF
--- a/django/publicmapping/config/config.xml
+++ b/django/publicmapping/config/config.xml
@@ -607,6 +607,6 @@
             <Upload maxsize="5300"/>
             <FixUnassigned minpercent="99" comparatorsubject="poptot" />
         </Redistricting>
-        <Mailer />
+        <Mailer submission_email="info+drawthelinespadev@azavea.com" />
     </Project>
 </DistrictBuilder>

--- a/django/publicmapping/context_processors.py
+++ b/django/publicmapping/context_processors.py
@@ -30,17 +30,17 @@ def banner_image(request):
     """
     Add a banner_image variable to the template context.
 
-    This context processors has to be added to the 
+    This context processors has to be added to the
     TEMPLATE_CONTEXT_PROCESSORS dictionary in settings.py to be available.
 
-    Users will need to set a BANNER_IMAGE variable in settings.py that 
-    points to the URL path to the banner image.  The banner image 
+    Users will need to set a BANNER_IMAGE variable in settings.py that
+    points to the URL path to the banner image.  The banner image
     defaults to '/static/images/banner-home.png'
 
     @param request: The HttpRequest
     """
     context_dict = {}
-    if 'BANNER_IMAGE' in settings.__members__:
+    if hasattr(settings, 'BANNER_IMAGE'):
         context_dict['banner_image'] = settings.BANNER_IMAGE
     else:
         context_dict['banner_image'] = '/static/images/banner-home.png'

--- a/django/publicmapping/redistricting/templates/editplan.html
+++ b/django/publicmapping/redistricting/templates/editplan.html
@@ -350,6 +350,32 @@
                 <td><input name="phone number" class="field required" maxlength="20" /></td>
             </tr>
             <tr>
+                <td class="fname">{% trans "County" %} *</td>
+                <td><input name="county" class="field required" maxlength="50" /></td>
+            </tr>
+            <tr>
+                <td class="fname">{% trans "Zip code" %} *</td>
+                <td><input name="zip" class="field required" maxlength="5" /></td>
+            </tr>
+            <tr>
+                <td class="fname">{% trans "Contest division" %} *</td>
+                <td>
+                    <select name="contest division" class="field required">
+                        <option value="youth">{% trans "Youth (Grades 5-12)" %}</option>
+                        <option value="higher-ed">{% trans "Higher Ed (Undergraduate, Graduate, Professional)" %}</option>
+                        <option value="adult">{% trans "Adult (Non-student)" %}</option>
+                    </select>
+            </tr>
+            <tr>
+                <td class="fname">{% trans "Region" %} *</td>
+                <td>
+                    <select name="region" class="field required">
+                        <option value="west">{% trans "West" %}</option>
+                        <option value="central">{% trans "Central" %}</option>
+                        <option value="east">{% trans "East" %}</option>
+                    </select>
+                </td>
+            <tr>
                 <td colspan="2" id="values_text_column">
                     {% trans "Values &ndash; tell us what values, considerations and trade-offs you made in your plan:" %}
                 </td>

--- a/django/publicmapping/redistricting/views.py
+++ b/django/publicmapping/redistricting/views.py
@@ -624,9 +624,7 @@ def commonplan(request, planid):
         len(ScoreDisplay.objects.filter(is_page=True)) > 0,
         'calculator_reports':
         json.dumps(calculator_reports),
-        'allow_email_submissions': ('EMAIL_SUBMISSION' in settings.__members__
-                                    if hasattr(settings, '__members__') else
-                                    False),
+        'allow_email_submissions': hasattr(settings, 'EMAIL_SUBMISSION'),
         'tags':
         tags,
         'site':


### PR DESCRIPTION
## Overview

C70 wants to collect additional parameters for contest submissions. This adds those parameters to the contest submission form, but doesn't go any further than that (see notes).

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

![dtlplansubmission](https://user-images.githubusercontent.com/447977/39130575-71f90ca4-46db-11e8-82fc-ef01138d7888.png)

### Notes

- The requested functionality, and the description for this task, both assume that the parameters entered in the contest submission form are being stored in the database. However, that turns out not to be the case; instead, the form contents are immediately emailed to a configurable email address, along with a CSV export of the relevant plan, and then forgotten:
    - https://github.com/azavea/district-builder-dtl-pa/blob/feature/capture-contest-details-%23156479506/django/publicmapping/redistricting/views.py#L2071
    - https://github.com/azavea/district-builder-dtl-pa/blob/feature/capture-contest-details-%23156479506/django/publicmapping/redistricting/tasks.py#L649
- The existing functionality has a lot of problems:
    - It means that contest submissions bypass the regular validation workflow that is required to submit to the leaderboards, which could result in invalid plans being submitted to C70.
    - It makes the workflow for submitting a validated plan counterintuitive and possibly not desirable (first submit to leaderboards, _then_ to C70).
    - C70 would have to re-import the submitted plans back into DistrictBuilder in order to evaluate them.
- Because of these discoveries, and because C70's desired functionality was based on the assumption that submissions were stored in the DistrictBuilder database, we are going to go back to them to gather further information about their needs before spending further effort on this story.
- This task exposed that DistrictBuilder was using a long-deprecated means of checking whether an object has a certain key; all two occurrences of that usage have been updated. The second instance of the usage (in `django/publicmapping/context_processors.py`) has not been tested because I don't know where or whether that section of code is used. I suspect that we currently aren't using it at all because accessing `__members__` on Python 2.7 raises an exception and we haven't seen any of that form. In any event, the change is small and unlikely to cause problems.

## Testing Instructions

 * Make sure you have the PA data loaded into your instance
 * Re-run `./scripts/update` in order to generate a new `config_settings.py`
 * Log in and navigate to the "Share" panel for one of your saved plans
 * Confirm that the Share panel has a section for contest submission and that clicking the button in that section reveals a popup that matches the screenshot above.

I've added @pcaisse as the primary reviewer; @kshepard and @tgilcrest are added as reviewers for context and to make sure that this matches what we discussed last week.
