### PR TITLE
Use LocustIO for load testing #156858139

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,9 @@ Vagrant.configure(2) do |config|
   # Nginx
   config.vm.network :forwarded_port, guest: 8080, host: 8080
 
+  # LocustIO (web interface for load testing tool)
+  config.vm.network :forwarded_port, guest: 8089, host: 8089
+
   # Change working directory to /vagrant upon session start.
   config.vm.provision "shell", inline: <<SCRIPT
     if ! grep -q "cd /vagrant" "/home/vagrant/.bashrc"; then

--- a/deployment/ansible/district-builder.yml
+++ b/deployment/ansible/district-builder.yml
@@ -10,3 +10,4 @@
     - { role: "azavea.python-security" }
     - { role: "district-builder.docker" }
     - { role: "district-builder.shellcheck" }
+    - { role: "district-builder.python" }

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -2,4 +2,4 @@
 
 shellcheck_version: "0.3.*"
 docker_compose_version: "1.16.*"
-pre_commit_version: "1.5.0"
+locustio_version: "0.8.1"

--- a/deployment/ansible/roles/district-builder.pre-commit/tasks/main.yml
+++ b/deployment/ansible/roles/district-builder.pre-commit/tasks/main.yml
@@ -1,4 +1,0 @@
----
-- name: Install pre-commit
-  local_action: command pip install pre-commit=="{{ pre_commit_version }}"
-  sudo: no

--- a/deployment/ansible/roles/district-builder.python/tasks/main.yml
+++ b/deployment/ansible/roles/district-builder.python/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Install LocustIO
+  pip: name=locustio version={{ locustio_version }}
+

--- a/locustfile.py
+++ b/locustfile.py
@@ -1,0 +1,97 @@
+"""
+Load testing script.
+
+Run via:
+
+$ locust
+
+Then visit http://localhost:8089 on host to run a test via the web UI.
+"""
+from locust import HttpLocust, TaskSet, task
+from hashlib import sha1
+from random import randint
+
+HOST = "http://localhost:8080"
+
+# NOTE: Change this based on your test user & plan
+USERNAME = 'testuser'
+PASSWORD = 'Test123$'
+PLAN_ID = 5
+
+# Configuration/instance specific. Assumes PA instance.
+NUM_DISTRICTS_IN_PLAN = 18
+REASSIGNMENT_POST_DATA = {
+    'geolevel': 2,
+    'geounits': 731,
+    'version': 0,
+}
+
+
+class UserActions(TaskSet):
+    def on_start(self):
+        self.login()
+
+    def login(self):
+        get_response = self.client.get('/accounts/login/')
+        csrftoken = get_response.cookies['csrftoken']
+        # Connection is unencrypted so the password is hashed before being sent
+        # to backend.
+        hashed_password = sha1(PASSWORD.encode('utf-8')).hexdigest()
+        # NOTE: Cookies are stored in client object
+        redirect_url = '/districtmapping/plan/{plan_id}/edit/'.format(
+            plan_id=PLAN_ID)
+        with self.client.post(
+                '/accounts/login/', {
+                    'username': USERNAME,
+                    'password': hashed_password,
+                    'next': redirect_url,
+                },
+                headers={'X-CSRFToken': csrftoken},
+                catch_response=True) as post_response:
+            if post_response.url != HOST + redirect_url:
+                post_response.failure('Authentication failed')
+
+    @task(1)
+    def index(self):
+        self.client.get('/')
+
+    @task(2)
+    def plan(self):
+        self.client.get(
+            '/districtmapping/plan/{plan_id}/edit/'.format(plan_id=PLAN_ID))
+
+    @task(10)
+    def reassign(self):
+        get_response = self.client.get(
+            '/districtmapping/plan/{plan_id}/edit/'.format(plan_id=PLAN_ID))
+        csrftoken = get_response.cookies['csrftoken']
+        # Reassign geounit to random district
+        with self.client.post(
+                '/districtmapping/plan/{plan_id}/district/{new_district}/add/'.
+                format(
+                    plan_id=PLAN_ID,
+                    new_district=randint(1, NUM_DISTRICTS_IN_PLAN),
+                ),
+                REASSIGNMENT_POST_DATA,
+                name=
+                '/districtmapping/plan/{plan_id}/district/[new_district]/add/'.
+                format(plan_id=PLAN_ID),
+                headers={'X-CSRFToken': csrftoken},
+                catch_response=True,
+                allow_redirects=False) as post_response:
+            # NOTE: If authentication has not worked properly, you will be
+            # redirected to the home page
+            if post_response.status_code == 302:
+                post_response.failure(
+                    'User was not authenticated to perform reassignment and was redirected to login page'
+                )
+            else:
+                if not post_response.json()['success']:
+                    post_response.failure('Failed to reassign geounit')
+
+
+class ApplicationUser(HttpLocust):
+    task_set = UserActions
+    host = HOST
+    min_wait = 0
+    max_wait = 0


### PR DESCRIPTION
## Overview

POC load testing script using Locust.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

**Configure Test through web UI**
![locust1](https://user-images.githubusercontent.com/2926237/39154123-349dad3e-471b-11e8-89c3-662cf9c6b1ec.png)

**Test in progress**
![locust2](https://user-images.githubusercontent.com/2926237/39154122-34937b0c-471b-11e8-8ea8-3c299ff0790d.png)

### Notes

This story was to choose a load testing tool for the DistrictBuilder PA instance. After some preliminary research, a few categories of tools emerged:

1. Full-featured GUI-based load testing applications written in Java (eg. JMeter, The Grinder, Gatling)
1. More obscure tools (eg. Tsung, written in Erlang and requiring you to write Bash & Perl scripts)
1. Locust (simple, very developer-friendly, written in Python)

Immediately Locust emerged as the front-runner. Using it amounts to running `pip install locustio`, writing a simple Python script, choosing the number of users and hatch rate, and running a test in the browser. Since do not have well-defined requirements for exactly what or how to test, it seemed to make sense to try out the dead-simplest thing first and see if that would meet our needs.

In order to do that, this POC script was written, demonstrating that we can use LocustIO to do some of the basic functions we plan on testing (authenticate and reassign geounits to districts).

Information provided by Locust tests (see screenshot):
* Statistics (including requests/sec)
* Charts
* Failures
* Exceptions

Since we are mostly interested in looking at how many reassignments per second we can handle, Locust should meet our needs. It is easy to mix in some different types of requests (just add a function and add the `@task` decorator); requests can be weighted to be made more often (see https://docs.locust.io/en/latest/api.html#task-decorator).

## Testing Instructions

* `vagrant provision`
* `vagrant ssh` and `./scripts/server`
* In a separate terminal session, `vagrant ssh` and `locust`
* Go to `http://localhost:8089` and run a test

## Links
* https://www.blazemeter.com/blog/open-source-load-testing-tools-which-one-should-you-use
* https://www.promptworks.com/blog/load-testing-with-locust
* http://blog.apcelent.com/load-test-django-application-using-locustio.html