### PR TITLE
Remove Google Plus from home page and shared map share page #156857511

### DIFF
--- a/django/publicmapping/publicmapping/templates/index.html
+++ b/django/publicmapping/publicmapping/templates/index.html
@@ -134,11 +134,6 @@
             <script src="https://connect.facebook.net/en_US/all.js#xfbml=1"></script>
             <fb:like width="90" show_faces="false" action="like" layout="button_count"></fb:like>
           </li>
-
-          <li class="google-plusone">
-            <script type="text/javascript" src="https://apis.google.com/js/plusone.js"></script>
-            <g:plusone size="medium"></g:plusone>
-          </li>
         </ul>
 
       </div>

--- a/django/publicmapping/redistricting/templates/viewplan.html
+++ b/django/publicmapping/redistricting/templates/viewplan.html
@@ -812,11 +812,6 @@
                     <script src="https://connect.facebook.net/en_US/all.js#xfbml=1"></script>
                     <fb:like width="90" show_faces="false" action="like" layout="button_count"></fb:like>
                   </li>
-
-                  <li class="google-plusone">
-                    <script type="text/javascript" src="https://apis.google.com/js/plusone.js"></script>
-                    <g:plusone size="medium"></g:plusone>
-                  </li>
                 </ul>
                   <div class="clear"></div>
                   </div>


### PR DESCRIPTION
## Overview

Remove Google Plus social media icon from DistrictBuilder.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

![google_plus1](https://user-images.githubusercontent.com/2926237/39250633-440bf154-486f-11e8-8e49-f29e65c0bca2.png)
![google_plus2](https://user-images.githubusercontent.com/2926237/39250635-441a4eca-486f-11e8-85cb-7c95fbf46bd9.png)

## Testing Instructions

* Go to home page and observe Google Plus icon is no longer there next to Facebook/Twitter
* Register/login
* Create/open shared map
* Go to "Share" tab
* Observe that Google Plus icon is gone from that page as well

Closes #156857511
