### PR TITLE
Switch to FB share button from Like button

### DIFF
--- a/django/publicmapping/publicmapping/templates/facebook_sdk.html
+++ b/django/publicmapping/publicmapping/templates/facebook_sdk.html
@@ -1,0 +1,10 @@
+    <!-- Load Facebook SDK for JavaScript -->
+    <div id="fb-root"></div>
+      <script>(function(d, s, id) {
+        var js, fjs = d.getElementsByTagName(s)[0];
+        if (d.getElementById(id)) return;
+        js = d.createElement(s); js.id = id;
+        js.src = "https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.12";
+        fjs.parentNode.insertBefore(js, fjs);
+      }(document, 'script', 'facebook-jssdk'));</script>
+

--- a/django/publicmapping/publicmapping/templates/index.html
+++ b/django/publicmapping/publicmapping/templates/index.html
@@ -35,6 +35,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=8" />
     <meta name="author" content="David Zwarg, Andrew Jennings, Kenny Shepard" />
     <meta name="copyright" content="&copy; 2010 Micah Altman, Michael McDonald"/>
+    <meta property="og:url" content="{{ request.build_absolute_uri }}" />
+    <meta property="og:type" content="website" />
     <meta property="og:title" content="DistrictBuilder: Web-based Open Source Software for Collaborative Redistricting" />
     <meta property="og:description" content="Draw your own redistricting plan by visiting the DistrictBuilder website." />
     <meta property="og:image" content="{% static 'images/db_sprite.png' %}"/>
@@ -74,11 +76,12 @@
   </head>
   <body id="static">
    <div class="static_wrap">
+     {% include "facebook_sdk.html" %}
 
    <div id="static_header">
       <div id="logo">
                <!--<img src="{% static 'images/title-static.png" />-->
-	       <span style="font-size:250%; font-family:arial,sans-serif; font-weight:bold; color:white">
+              <span style="font-size:250%; font-family:arial,sans-serif; font-weight:bold; color:white">
                  {% trans "DistrictBuilder" %}
                </span>
       </div>
@@ -87,7 +90,7 @@
 
         <!--
           <li><a href="">item</a></li>
-	-->
+       -->
           <li><a href="http://www.publicmapping.org">{% trans "About" %}</a></li>
           <li>
             <a class="last" href="mailto:support@districtbuilder.org?subject=%5BDistrictBuilder%5D%20Support%20Request">
@@ -133,9 +136,17 @@
           </li>
 
           <li class="facebook-like">
-            <div id="fb-root"></div>
-            <script src="https://connect.facebook.net/en_US/all.js#xfbml=1"></script>
-            <fb:like width="90" show_faces="false" action="like" layout="button_count"></fb:like>
+            <div
+              class="fb-share-button"
+              data-href="{{ request.build_absolute_uri }}"
+              data-layout="button_count"
+              data-size="small"
+              data-mobile-iframe="true">
+                <a target="_blank"
+                  href="https://www.facebook.com/sharer/sharer.php?u={{ request.build_absolute_url|urlencode }}&amp;src=sdkpreparse"
+                  class="fb-xfbml-parse-ignore">{% trans "Share" %}
+                </a>
+            </div>
           </li>
 
           <li class="email-share">

--- a/django/publicmapping/redistricting/templates/viewplan.html
+++ b/django/publicmapping/redistricting/templates/viewplan.html
@@ -37,7 +37,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=8" />
     <meta name="author" content="David Zwarg, Andrew Jennings, Kenny Shepard" />
     <meta name="copyright" content="&copy; 2010 Micah Altman, Michael McDonald"/>
-    <meta property="og:title" content="{% trans "Redistricting plan by DistrictBuilder" %}" />
+    <meta property="og:url" content="{{ request.build_absolute_uri }}" />
+    <meta property="og:title" content="{% trans "DistrictBuilder redistricting plan: " %}{{ plan.legislative_body.name|title }} - {{ plan.name}} - {{ user.username }}" />
+    <meta property="og:type" content="website" />
     <meta property="og:description" content="{% trans "DistrictBuilder is web-based, open source software for collaborative redistricting." %}" />
     <meta property="og:image" content="{% static 'images/db_sprite.png' %}" />
     <title>{% trans "Open Source District Mapping Tool" %}</title>
@@ -209,7 +211,7 @@
 
   </head>
   <body onload="init();" id="app">
-
+    {% include "facebook_sdk.html" %}
 
 
   <div id="steps" style="visibility: hidden;">
@@ -804,14 +806,20 @@
                   </li>
                     <script type="text/javascript" src="https://platform.twitter.com/widgets.js"></script>
                     <script>
-                        // Hack to get the Twitter button to load properly.
-                        // If loaded immediately via regular HTML markup + Twitter script execution,
-                        // the iFrame that is loaded is 1x1 and the button itself has no width.
-                        // This is related to the eccentricities of Twitter's script running immediately
-                        // on a link with this parent element. Workaround is to load it dynamically
-                        // when the "Share" tab is clicked.
-                        function createTwitterButton() {
+                        // Hack to get the Twitter and Facebook buttons to load properly.
+                        // If loaded immediately via regular HTML markup + script execution,
+                        // the iFrame that is loaded is 1x1 and the buttons have no width.
+                        // This is related to the eccentricities of the share buttons' scripts 
+                        // running immediately on a link with this parent element. The Twitter
+                        // workaround is to load it dynamically when the "Share" tab is clicked.
+                        // The Facebook button will recompute if the DOM structure changes, so this
+                        // introduces an artificial change on page load. This might work for Twitter
+                        // too, but hasn't been tested.
+                        function createShareButtons() {
                             var twitterLinkContainer = document.querySelector('.twitter-tweet');
+                            var fbLikeContainer = document.querySelector('.facebook-like');
+                            var emailContainer = document.querySelector('.email-share');
+                            emailContainer.parentNode.insertBefore(fbLikeContainer, emailContainer);
                             if (twitterLinkContainer.children.length === 0) {
                                 // Create new anchor tag with appropriate attributes
                                 var twitterLink = document.createElement('a');
@@ -829,16 +837,24 @@
                         }
                     </script>
 
-                  <li class="facebook-like">
-                    <div id="fb-root"></div>
-                    <script src="https://connect.facebook.net/en_US/all.js#xfbml=1"></script>
-                    <fb:like width="90" show_faces="false" action="like" layout="button_count"></fb:like>
-                  </li>
-
                   <li class="email-share">
                     <a id="email-share-link">
                       <button id="email-share-button"><img id="email-share-img" src="{% static 'images/icon-mail.png' %}"></button>
                     </a>
+                  </li>
+
+                  <li class="facebook-like">
+                    <div
+                      class="fb-share-button"
+                      data-href="{{ request.build_absolute_uri }}"
+                      data-layout="button_count"
+                      data-size="small"
+                      data-mobile-iframe="true">
+                        <a target="_blank"
+                          href="https://www.facebook.com/sharer/sharer.php?u={{ request.build_absolute_url|urlencode }}&amp;src=sdkpreparse"
+                          class="fb-xfbml-parse-ignore">Share
+                        </a>
+                    </div>
                   </li>
 
                   <script type="text/javascript">
@@ -1219,8 +1235,8 @@ Include the markup for the account management panel.
         $('#steps').tabs({ show: function(event, ui) {
             if ($(this).tabs('option', 'selected') == 3) {
                 exportIndexFile.init();
-                if (typeof createTwitterButton === "function") {
-                    createTwitterButton();
+                if (typeof createShareButtons === "function") {
+                    createShareButtons();
                 }
             }
         }});


### PR DESCRIPTION
## Overview

Swaps out the Facebook Like buttons on the homepage and plan Sharing page for FB Share buttons instead.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

<img width="169" alt="screen shot 2018-04-26 at 12 25 05 pm" src="https://user-images.githubusercontent.com/447977/39318723-e13ea484-494c-11e8-9df2-266c050a161c.png">


### Notes

- Doing this uncovered that the domain name isn't getting properly set in `settings.py`. We currently always set `ALLOWED_HOSTS` to `['web']`, which is what results from running via docker-compose, but this means that whenever Django generates a hostname, it ends up as `http://web/whatever/` which is incorrect. We're going to need to make sure that we can tell Django what domain it is running on; I've added [#157125912](https://www.pivotaltracker.com/story/show/157125912) for this.
- The dialog that pops up when you click this button always closes immediately, whether or not you are logged into Facebook. I suspect that this is because FB is detecting the invalid domain name problem and bailing out.

## Testing Instructions

 * Navigate to the homepage and confirm that there is a FB share button available.
 * View source and confirm that the `og:*` meta tags in the header contain appropriate values
 * Share a plan and then visit its Share page, and confirm that there is a FB share button available there as well.
 * View source and confirm that the `og:*` meta tags contain appropriate values here; specifically, the title should include the legislative body, plan name, and username.

Closes #156479159
