### PR TITLE
Add custom text and hashtags to Twitter links #156857315

### DIFF
--- a/django/publicmapping/publicmapping/templates/index.html
+++ b/django/publicmapping/publicmapping/templates/index.html
@@ -123,7 +123,10 @@
 
         <ul class="share-buttons">
           <li class="twitter-tweet">
-            <a href="https://twitter.com/share" class="twitter-share-button" data-count="horizontal">
+            <a href="https://twitter.com/intent/tweet"
+              data-text="{% trans 'Homepage tweet text' %}"
+              data-hashtags="redistricting"
+              class="twitter-share-button">
               {% trans "Tweet" %}
             </a>
             <script type="text/javascript" src="https://platform.twitter.com/widgets.js"></script>

--- a/django/publicmapping/redistricting/templates/viewplan.html
+++ b/django/publicmapping/redistricting/templates/viewplan.html
@@ -801,11 +801,28 @@
                       </script>
                  <ul class="share-buttons">
                   <li class="twitter-tweet">
-                    <a href="https://twitter.com/share" class="twitter-share-button" data-count="horizontal">
-                      {% trans "Tweet" %}
-                    </a>
-                    <script type="text/javascript" src="https://platform.twitter.com/widgets.js"></script>
                   </li>
+                    <script type="text/javascript" src="https://platform.twitter.com/widgets.js"></script>
+                    <script>
+                        // Hack to get the Twitter button to load properly
+                        function createTwitterButton() {
+                            var twitterLinkContainer = document.querySelector('.twitter-tweet');
+                            if (twitterLinkContainer.children.length === 0) {
+                                // Create new anchor tag with appropriate attributes
+                                var twitterLink = document.createElement('a');
+                                twitterLink.href = "https://twitter.com/intent/tweet";
+                                twitterLink.className = "twitter-share-button";
+                                twitterLink.setAttribute("data-text", "{% trans "Shared map tweet text" %}");
+                                twitterLink.setAttribute("data-hashtags", "redistricting");
+                                twitterLink.innerHTML = "{% trans "Tweet" %}";
+                                // Insert into container
+                                var twitterLinkContainer = document.querySelector('.twitter-tweet');
+                                twitterLinkContainer.appendChild(twitterLink);
+                                // Tell Twitter library to load new widget
+                                twttr.widgets.load(twitterLinkContainer);
+                            }
+                        }
+                    </script>
 
                   <li class="facebook-like">
                     <div id="fb-root"></div>
@@ -1191,6 +1208,7 @@ Include the markup for the account management panel.
         $('#steps').tabs({ show: function(event, ui) {
             if ($(this).tabs('option', 'selected') == 3) {
                 exportIndexFile.init();
+                createTwitterButton();
             }
         }});
 


### PR DESCRIPTION
## Overview

Add Twitter buttons with appropriate placeholder data to home page and shared map page.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Notes

#### The Hack

On the home page, everything worked fine with the Twitter link with very little effort.

However, this PR contains a hack to get it to work on the shared map page.

For the Twitter button, normally you would create a Twitter link using regular HTML markup and then call Twitter's script which will find any existing Twitter links and load them into a widget by creating an iFrame with the actual button content. The Twitter script tries to be smart and will adjust its size based on its container. For some reason, on the shared map page when doing it the normal way, the script sets the iFrame's height/width to 1x1 px and the widget container width to zero. To get it to work, we dynamically add the link and tell the Twitter script to load the widget only when the "Share" tab is clicked.

As a result of this workaround, the Twitter link would break if the user was able to load the "Share" tab directly without clicking (not currently possible).

#### Translations

We don't yet know what the placeholder text should show in the modals when the buttons are clicked. For right now it just uses the translation key (unsure if we can merge without that copy). I also assumed they they would want the #redistricting hashtag, but that's just something I made up.

This shows the params we could set: https://dev.twitter.com/web/tweet-button/parameters

## Testing Instructions

* Go to home page
* Make sure Twitter button displays appropriately and that the modal has the correct text
* Log in. Create/view a shared plan and click "Share" tab. 
* Make sure Twitter button displays appropriately and that the modal has the correct text

