### PR TITLE
Remove region from contest submission

### DIFF
--- a/django/publicmapping/redistricting/templates/editplan.html
+++ b/django/publicmapping/redistricting/templates/editplan.html
@@ -365,16 +365,8 @@
                         <option value="higher-ed">{% trans "Higher Ed (Undergraduate, Graduate, Professional)" %}</option>
                         <option value="adult">{% trans "Adult (Non-student)" %}</option>
                     </select>
-            </tr>
-            <tr>
-                <td class="fname">{% trans "Region" %} *</td>
-                <td>
-                    <select name="region" class="field required">
-                        <option value="west">{% trans "West" %}</option>
-                        <option value="central">{% trans "Central" %}</option>
-                        <option value="east">{% trans "East" %}</option>
-                    </select>
                 </td>
+            </tr>
             <tr>
                 <td colspan="2" id="values_text_column">
                     {% trans "Values &ndash; tell us what values, considerations and trade-offs you made in your plan:" %}


### PR DESCRIPTION
## Overview

Remove region from contest submission.

### Checklist

- [ ] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

 * `vagrant ssh`
 * `./scripts/server`
 * Go to the share tab of an unshared plan. Submit to contest. Check that region does not appear on the popup as a field.
