### PR TITLE
Remove Spanish language option

### DIFF
--- a/django/publicmapping/config/config.xml
+++ b/django/publicmapping/config/config.xml
@@ -686,7 +686,6 @@
     <Project sessionquota="5000" sessiontimeout="15">
         <Internationalization timezone="US/Eastern" default="en">
             <Language code="en" label="English" />
-            <Language code="es" label="Spanish" />
         </Internationalization>
         <Redistricting>
             <MapServer


### PR DESCRIPTION
## Overview

Translating to Spanish is not covered in this round of funding. Removing the option, since the Spanish translations will only be partially working until we have the time to perform the translations.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

 * `vagrant ssh`
 * `scripts/update` (important -- this reads the `config.xml` file and creates a new `config_settings.py`
 * `scripts/server`
 * Browse to the app and verify that there is no language dropdown for Spanish.

## Notes

I was hoping having one language option would hide the language dropdown, but it doesn't. We'll need to add some logic if that's the desired behavior.


