### PR TITLE
Make geoserver data dir persistent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,7 @@ services:
     env_file:
       - .env
     volumes:
+      - data:/data
       - sld:/data/sld
     ports:
       - "${MAP_SERVER_PORT}:${WEB_APP_PORT}"


### PR DESCRIPTION
## Overview

Previously, only one subfolder of GEOSERVER_DATA_DIR (`/data/sld`) was persisted using a Docker volume mount. As a result, anytime GeoServer was removed and re-created, the remaining configuration (reset password, stored layers) were lost. This commit makes the entire GEOSERVER_DATA_DIR persistent by using a Docker volume.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] ~Files changed in the PR have been `yapf`-ed for style violations~

### Demo

https://pa.districtbuilder.azavea.com

### Notes

This change has been applied to Staging. On the PA App Server, I  did the following:
```bash
$ cd /opt/district-builder
$ docker-compose down -v
$ sudo restart district-builder
# Wait for service to initialize
$ docker exec -it districtbuilder-geoserver ./bin/change_admin_password.sh
$ docker exec -it districtbuilder-app ./manage.py setup config/config.xml -G
# Edit a shared plan at pa.districtbuilder.azavea.com, ensure tiles are styled correctly
$ sudo restart district-builder
# Edit a shared plan at pa.districtbuilder.azavea.com, ensure tiles are styled correctly
```

## Testing Instructions

* SSH into the PA App server
* run `sudo restart district-builder`
* Visit http://origin.pa.districtbuilder.azavea.com:8080, and try to edit one of the shared plans. Ensure that map tiles are styled correctly.

* Closes #22 
* Connects PublicMapping/DistrictBuilder#548
