### PR TITLE
Add Mapbox municipalities basemap

### DIFF
--- a/django/publicmapping/config/config.xml
+++ b/django/publicmapping/config/config.xml
@@ -691,7 +691,7 @@
             <MapServer
                 ns="pmp"
                 nshref="https://github.com/PublicMapping/"
-                basemaps="osm-road,arc-road,arc-topo,arc-dark"
+                basemaps="arc-topo,arc-road,mapbox-municipality"
                 maxfeatures="500" />
             <Upload maxsize="5300"/>
             <FixUnassigned minpercent="99" comparatorsubject="poptot" />

--- a/django/publicmapping/static/js/mapping.js
+++ b/django/publicmapping/static/js/mapping.js
@@ -374,6 +374,25 @@ function mapinit(srs,maxExtent) {
                 }
                 break;
 
+            case 'mapbox':
+                var mapboxUrl = window.location.protocol +
+                    "//api.mapbox.com/styles/v1/tgilcrest/cjfx0n99k069t2rq8tw784u2h/tiles/256/" +
+                    "${z}/${x}/${y}?access_token=" +
+                    "pk.eyJ1IjoidGdpbGNyZXN0IiwiYSI6ImNqZnd6d2pqMzBqc2MzMm53MGgybWltOXAifQ.I2v96bMX7g-XPckWlDwJ5Q";
+
+                options = {
+                    numZoomLevels: numZoomLevels,
+                    minZoomLevel: minZoomLevel,
+                    projection: projection,
+                    sphericalMercator: true,
+                    maxExtent: maxExtent
+                };
+
+                if (mapType === 'municipality') {
+                    return new OpenLayers.Layer.XYZ(layerName, [mapboxUrl], options);
+                }
+                break;
+
             default:
                 return null;
         }
@@ -385,7 +404,8 @@ function mapinit(srs,maxExtent) {
         hybrid: { label: gettext('Hybrid') },
         road: { label: gettext('Road') },
         topo: { label: gettext('Topo') },
-        dark: { label: gettext('Dark') }
+        dark: { label: gettext('Dark') },
+        municipality: { label: gettext('Municipality') }
     };
 
     // Construct each layer, and assign a label.


### PR DESCRIPTION
## Overview

This PR adds a selectable Mapbox basemap whose purpose is to show municipalities. The list of configured basemaps in order from left to right is now: ESRI topo, ESRI road, and Mapbox municipalities (OSM and ESRI dark have been removed per client request).

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

![dtl-mapbox-muni](https://user-images.githubusercontent.com/6386/40332432-1fa694b4-5d22-11e8-8b55-54bb7eecd58a.png)

### Notes

I checked with Tyler, and it is not necessary to account for the configuration of multiple Mapbox basemaps, or any fancy URL configuration. If we want to change the URL or token, we will just modify the JavaScript file.

## Testing Instructions

* vagrant ssh
* scripts/update
* scripts/server
* Browse to the map page and verify that there is a `Municipalities` selection available. Choose it and verify that the Mapbox tiles are displaying.
