### PR TITLE
Add Heap analytics tracking

### DIFF
--- a/django/publicmapping/publicmapping/templates/index.html
+++ b/django/publicmapping/publicmapping/templates/index.html
@@ -73,6 +73,12 @@
             openusername = '{{ user.username }}',
             availsession = {% if sessionavail %}true{% else %}false{% endif %};
     </script>
+
+    <!-- Heap analytics snippet -->
+    <script type="text/javascript">
+      window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
+      heap.load("304904070");
+    </script>
   </head>
   <body id="static">
    <div class="static_wrap">
@@ -325,6 +331,9 @@
       <div class="attribution">
         <!-- Keep this on one line to avoid an underscore in Chrome -->
         <a target="_blank" href="http://www.districtbuilder.org"><img alt="{% trans "Powered By DistrictBuilder" %}" src="{% static 'images/db_sprite.png' %}"></a>
+
+        <!-- Heap badge program, see: https://heapanalytics.com/badge -->
+        <a href="https://heapanalytics.com/?utm_source=badge" rel="nofollow"><img style="width:108px;height:41px" src="//heapanalytics.com/img/badge.png" alt="Heap | Mobile and Web Analytics" /></a>
         <br>
         <span id="poweredbytext">
           {% trans "A project of" %}

--- a/django/publicmapping/redistricting/templates/viewplan.html
+++ b/django/publicmapping/redistricting/templates/viewplan.html
@@ -209,6 +209,11 @@
         </script>
     {% endif %}
 
+    <!-- Heap analytics snippet -->
+    <script type="text/javascript">
+      window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
+      heap.load("304904070");
+    </script>
   </head>
   <body onload="init();" id="app">
     {% include "facebook_sdk.html" %}
@@ -809,7 +814,7 @@
                         // Hack to get the Twitter and Facebook buttons to load properly.
                         // If loaded immediately via regular HTML markup + script execution,
                         // the iFrame that is loaded is 1x1 and the buttons have no width.
-                        // This is related to the eccentricities of the share buttons' scripts 
+                        // This is related to the eccentricities of the share buttons' scripts
                         // running immediately on a link with this parent element. The Twitter
                         // workaround is to load it dynamically when the "Share" tab is clicked.
                         // The Facebook button will recompute if the DOM structure changes, so this


### PR DESCRIPTION
## Overview

Adds Heap analytics tracking to all pages on the app. Also includes a badge on the landing page to allow us to track 50,000 sessions per month for free.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

![dtl-heap](https://user-images.githubusercontent.com/6386/40378675-46709766-5dc2-11e8-8901-f641d15b84a9.png)

## Testing Instructions

 * Browse to the web app
 * Ensure the Heap badge is visible on the landing page
 * Open up your network tab, filter by 'heap'
 * Reload the page and ensure there's some Heap network activity
 * Login, browse around the app and ensure there's Heap network activity throughout

Closes #157646460
