### PR TITLE
Add competitiveness score to sidebar

### DIFF
--- a/django/publicmapping/config/config.xml
+++ b/django/publicmapping/config/config.xml
@@ -416,6 +416,15 @@
                 description="Each plan&apos;s overall political competitiveness is determined by averaging each district.s &apos;partisan differential&apos;.  The partisan differential of each district is calculated by subtracting the Democratic &apos;partisan index&apos; from the Republican &apos;partisan index&apos;.&lt;br/&gt;&lt;br/&gt;&apos;Heavily&apos; competitive districts are districts with partisan differentials of less than or equal to 5%. &apos;Generally&apos; competitive districts are districts with partisan differentials of greater than 5% but less than 10%.">
                 <SubjectArgument name="democratic" ref="votedem" />
                 <SubjectArgument name="republican" ref="voterep" />
+                <Argument name="target" value="18"/>
+            </ScoreFunction>
+
+            <ScoreFunction id="congress_plan_competitiveness_leaderboard" type="plan"
+                calculator="redistricting.calculators.Competitiveness"
+                label="Competitiveness"
+                description="Each plan&apos;s overall political competitiveness is determined by averaging each district.s &apos;partisan differential&apos;.  The partisan differential of each district is calculated by subtracting the Democratic &apos;partisan index&apos; from the Republican &apos;partisan index&apos;.&lt;br/&gt;&lt;br/&gt;&apos;Heavily&apos; competitive districts are districts with partisan differentials of less than or equal to 5%. &apos;Generally&apos; competitive districts are districts with partisan differentials of greater than 5% but less than 10%.">
+                <SubjectArgument name="democratic" ref="votedem" />
+                <SubjectArgument name="republican" ref="voterep" />
             </ScoreFunction>
 
             <ScoreFunction id="congress_plan_polsbypopper" type="plan"
@@ -518,13 +527,13 @@
             <ScorePanel id="panel_competitiveness_all" type="plan" position="3"
                 title="Competitiveness" template="leaderboard_panel_all.html"
                 is_ascending="false">
-                <Score ref="congress_plan_competitiveness" />
+                <Score ref="congress_plan_competitiveness_leaderboard" />
             </ScorePanel>
 
             <ScorePanel id="panel_competitiveness_mine" type="plan" position="3"
                 title="Competitiveness" template="leaderboard_panel_mine.html"
                 is_ascending="false">
-                <Score ref="congress_plan_competitiveness" />
+                <Score ref="congress_plan_competitiveness_leaderboard" />
             </ScorePanel>
 
             <!-- Summary above all sidebar panels -->
@@ -534,6 +543,7 @@
                 <Score ref="congress_plan_noncontiguous"/>
                 <Score ref="congress_plan_polsbypopper"/>
                 <Score ref="congress_plan_equivalence"/>
+                <Score ref="congress_plan_competitiveness"/>
             </ScorePanel>
 
             <!-- Basic Information -->

--- a/django/publicmapping/redistricting/calculators.py
+++ b/django/publicmapping/redistricting/calculators.py
@@ -1627,7 +1627,10 @@ class Competitiveness(CalculatorBase):
     This calculator only operates on Plans.
 
     This calculator requires three arguments: 'democratic', 'republican',
-        and 'range'
+        and 'range', and has one optional argument: 'target'.
+
+    If 'target' is set, the calculator will format the result to include
+        the target value in parenthesis after the calculated value.
     """
 
     def compute(self, **kwargs):
@@ -1675,6 +1678,17 @@ class Competitiveness(CalculatorBase):
                 fair += 1
 
         self.result = {'value': fair}
+        try:
+            target = self.get_value('target')
+            if target != None:
+                self.result = {
+                    'value': _('%(value)d (of %(target)s)') % {
+                        'value': fair,
+                        'target': target
+                    }
+                }
+        except:
+            pass
 
 
 class CountDistricts(CalculatorBase):


### PR DESCRIPTION
## Overview

Adds competitiveness to the plan scores section in the sidebar.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

![dtl-competitiveness-sidebar](https://user-images.githubusercontent.com/6386/40383830-d7cb5ba8-5dcf-11e8-9f78-2a1d3ff1a2d1.png)

![dtl-competitiveness-leaderboard](https://user-images.githubusercontent.com/6386/40383835-da5d2a4a-5dcf-11e8-9e68-fc61bac6ca74.png)

### Notes

I don't love the code for adding the target formatting to the calculator, but this is the same way it's done in several other calculators, so I wanted to keep it identical in case we want to refactor them all in the future.

## Testing Instructions

* ssh into the VM and run: scripts/configure_pa_data (note: this will clear your database)
* Run scripts/server
* Browse to the site, create a user, and create a plan from a template
* Verify that a Competitiveness score shows up on the sidebar, and is formatted such as `x (of 18)`
* For extra credit, make a valid plan, submit to the leaderboard, and ensure the competitiveness score just shows the raw number, rather than the `x (of 18)` formatting. 

Closes #157605960
