### PR TITLE
Pin to kombu==4.1.0 to avoid breaking Celery

### DIFF
--- a/django/publicmapping/requirements.txt
+++ b/django/publicmapping/requirements.txt
@@ -5,6 +5,7 @@ gevent==1.2.2
 Django==1.11.10
 psycopg2==2.7.3
 celery[redis]==4.1.0
+kombu==4.1.0
 django-redis==4.8.0
 django-rosetta==0.7.13
 django-staticfiles==1.2.1


### PR DESCRIPTION
## Overview

Secondary dependency (`kombu`) broke out from under us. This is the same fix as:
https://github.com/WikiWatershed/model-my-watershed/commit/008d02befce5533a6ee56302b84db2507b53ec13

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- ~[ ] Files changed in the PR have been `yapf`-ed for style violations~

## Testing Instructions

 * On `develop`, to reproduce the broken state you would find yourself in with a fresh repo, make this change:
```diff
diff --git a/django/publicmapping/Dockerfile b/django/publicmapping/Dockerfile
index 67b6538..fc04081 100644
--- a/django/publicmapping/Dockerfile
+++ b/django/publicmapping/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
     git gcc wget unzip

 COPY requirements.txt /usr/src/app/
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --ignore-installed -r requirements.txt

 COPY . /usr/src/app
```
* Run `docker-compose build` to reinstall Python deps
* Run `docker-compose up` and note that Celery is :boom: 
* Undo change to `Dockerfile` and check out this branch
* `docker-compose build && docker-compose up`
* Celery should now be :100: 