### PR TITLE
Exclude xmlconfig.po from Vagrant rsync

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,8 @@ Vagrant.configure(2) do |config|
                        "reports/",
                        "geoserver/data_dir/",
                        "django/publicmapping/publicmapping/config_settings.py",
-                       "django/publicmapping/locale/*/*.mo"],
+                       "django/publicmapping/locale/**/*.mo",
+                       "django/publicmapping/locale/**/xmlconfig.po"],
       rsync__args: ["--verbose", "--archive", "--delete", "-z", "--links"]
 
   config.vm.provider :virtualbox do |vb|


### PR DESCRIPTION
## Overview

Exclude `xmlconfig.po` from Vagrant rsync.

`xmlconfig.po` is derived from `config.xml`. As such, it should not be put into the VM where it overrides the `xmlconfig.po` file generated by the `django` container.

There was a bug that manifested itself as follows: whenever a file was changed with `vagrant rsync-auto` running, `xmlconfig.po` within the VM would be overwritten. If you would re-configure by running `./manage.py setup config/config.xml`, the file would then be generated correctly, but any other change to a file with rysnc-auto running would overwrite it again.

This change makes it so that other `.po` files that are committed to source control with proper translations (such as `django.po`) will still make their way into the VM while `xmlconfig.po` will not.

A change to fix globbing to ignore `.mo` files in nested subfolders is also included.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- ~~[ ] Files changed in the PR have been `yapf`-ed for style violations~~

### Notes

I believe this bug was introduced in https://github.com/azavea/district-builder-dtl-pa/pull/9. I'm not sure how that fixed worked since the globbing syntax seems to be off (must be `**` instead of `*`). Perhaps the fix just _seemed_ to have an effect due to the vagaries of the working copy -> VM -> container indirection.

### Screenshots

#### Before
![screenshot from 2018-05-29 16-53-41](https://user-images.githubusercontent.com/2926237/40863460-eb28afe8-65bd-11e8-8d1b-b3b6524fdd12.png)

#### After
![screenshot from 2018-06-01 17-05-14](https://user-images.githubusercontent.com/2926237/40863471-f7f0f348-65bd-11e8-8e2c-bfbf002c8621.png)

## Testing Instructions

### Steps to Reproduce Bug

 * On `develop` with `vagrant rsync-auto` running, load up the app and notice broken translations in "Demographics" side panel (eg. http://localhost:8080/districtmapping/plan/2/view/)
* Within VM, run `docker-compose exec django bash` and then within container run `./manage.py setup config/config.xml`. This will regenerate `xmlconfig.po` within the container and in the VM due to the shared volume.
* Restart the app and notice the translations are fixed!
* Make any change to source code to trigger an rsync (and subsequently overwrite the `xmlconfig.po` file we generated).
* Restart app and notice translations are broken again

### Demonstrate Fix

* Check out this branch
* Kill `vagrant rsync-auto`
* Run `vagrant reload`
* Run `vagrant rysnc-auto` again (new excludes should be reflected)
* Repeat steps to reproduce (must run `./manage.py setup config/config.xml` within container once to fix translations) and notice translations are fixed even after changing source code and restarting app.