### PR TITLE
Fix Polsby-Popper reports

### DIFF
--- a/django/publicmapping/redistricting/reportcalculators.py
+++ b/django/publicmapping/redistricting/reportcalculators.py
@@ -29,7 +29,13 @@ Author:
 """
 
 from django.utils.translation import ugettext as _
-from redistricting.calculators import CalculatorBase, LengthWidthCompactness, Roeck, Schwartzberg
+from redistricting.calculators import (
+    CalculatorBase,
+    LengthWidthCompactness,
+    PolsbyPopper,
+    Roeck,
+    Schwartzberg,
+)
 
 
 class Population(CalculatorBase):
@@ -84,7 +90,7 @@ class Compactness(CalculatorBase):
     This calculator only operates on districts. It accepts one required
     argument: "comptype", which allows the specification of which type of
     compactness calculation will be performed. Currently available comptypes
-    are: 'LengthWidth', 'Roeck', and 'Schwartzberg'
+    are: 'LengthWidth', 'Roeck', 'Schwartzberg', and 'PolsbyPopper'
     """
 
     def compute(self, **kwargs):
@@ -98,8 +104,10 @@ class Compactness(CalculatorBase):
             calc = Roeck()
         elif comptype == 'Schwartzberg':
             calc = Schwartzberg()
+        elif comptype == 'PolsbyPopper':
+            calc = PolsbyPopper()
         else:
-            return
+            raise ValueError('Invalid compactness calculator')
 
         calc.compute(district=district)
         val = calc.result['value'] if calc.result else 0


### PR DESCRIPTION
## Overview

Fix Polsby-Popper reports by adding `PolsbyPopper` as a calculator for compactness reports.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Screenshots

**Now looks like this**
![screenshot from 2018-06-06 15-54-51](https://user-images.githubusercontent.com/2926237/41061859-083995ce-69a2-11e8-89e3-06bbf584d579.png)

**Invalid config should show this**
![screenshot from 2018-06-06 15-39-16](https://user-images.githubusercontent.com/2926237/41061883-187c61d2-69a2-11e8-8c43-ae61c2327754.png)


## Testing Instructions

* On this branch, run app (restart app if running)
* Create new plan
* Click "Evaluate" tab
* Select "Polsby-Popper" and then click "Create and Preview New Report" button
* Observe report is correctly generated

Note that there is a lot of caching. You need to both restart the app and also create a new plan for this to work correctly.
