### PR TITLE
Fix district index file upload

### DIFF
--- a/django/publicmapping/redistricting/views.py
+++ b/django/publicmapping/redistricting/views.py
@@ -953,6 +953,7 @@ def uploadfile(request):
                 filename = '%s%s' % (dest.name, '.zip')
             else:
                 filename = dest.name
+            os.chmod(filename, 0664)
 
         except Exception as ex:
             logger.error('Could not save uploaded file')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     volumes:
       - reports:/opt/reports
       - sld:/opt/sld
+      - tmp:/tmp
     entrypoint: /usr/local/bin/gunicorn
     command:
       - "--workers=2"
@@ -57,6 +58,7 @@ services:
       - .env
     volumes:
       - reports:/opt/reports
+      - tmp:/tmp
     entrypoint: /usr/local/bin/celery
     command:
       - "worker"
@@ -94,3 +96,4 @@ volumes:
   reports:
   data:
   sld:
+  tmp:


### PR DESCRIPTION
## Overview

This fix was already implemented for DistrictBuilder core. This PR just includes the cherry-picked commit from https://github.com/PublicMapping/DistrictBuilder/pull/535/files

## Testing Instructions

Probably doesn't need to be fully tested because of ultra-turbo-pteradactyl mode. Just compare the changes to https://github.com/PublicMapping/DistrictBuilder/pull/535/files and make sure they make sense.
