### PR TITLE
Order score displays alphabetically by title #157411581

### DIFF
--- a/django/publicmapping/redistricting/views.py
+++ b/django/publicmapping/redistricting/views.py
@@ -2611,7 +2611,7 @@ def statistics_sets(request, planid):
         admin_displays = ScoreDisplay.objects.filter(
             owner__is_superuser=True,
             legislative_body=plan.legislative_body,
-            name__in=admin_display_names)
+            name__in=admin_display_names).order_by('title')
 
         for admin_display in admin_displays:
             sets.append({


### PR DESCRIPTION
## Overview

Order score displays alphabetically by title.

This seems like a reasonable default ordering, happens to achieve what we want ("Basic Information" showing up first), and is much quicker and easier than making changes to allow for configuring the display order.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

Run app and make sure that "Basic Information" is the first option in the dropdown:

![screenshot from 2018-06-08 13-25-14](https://user-images.githubusercontent.com/2926237/41171686-6a254890-6b1f-11e8-9495-0b8429f4b678.png)

## PivotalTracker

https://www.pivotaltracker.com/story/show/157411581