### PR TITLE
Embed Leaflet into plan submission report

### DIFF
--- a/django/publicmapping/redistricting/management/commands/submission_report.py
+++ b/django/publicmapping/redistricting/management/commands/submission_report.py
@@ -1,6 +1,7 @@
 import os.path
 import codecs
 
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.management.base import BaseCommand
 from django.core import serializers
 from django.template import loader
@@ -44,9 +45,13 @@ class Command(BaseCommand):
             geometry_field='geom',
             fields=('short_label', 'long_label')
         )
+        leaflet_css = staticfiles_storage.open('leaflet/leaflet.css').read()
+        leaflet_js = staticfiles_storage.open('leaflet/leaflet.js').read()
         context = dict(
             submission=submission,
             scores_html=scores_html,
+            leaflet_css=leaflet_css,
+            leaflet_js=leaflet_js,
             geojson=geojson
         )
 

--- a/django/publicmapping/redistricting/templates/submission_summary.html
+++ b/django/publicmapping/redistricting/templates/submission_summary.html
@@ -3,8 +3,12 @@
 <html>
   <head>
     <title>Draw The Lines PA</title>
-    <link rel="stylesheet" type="text/css" href="{% static 'leaflet/leaflet.css' %}">
-    <script type="text/javascript" src="{% static 'leaflet/leaflet.js' %}"></script>
+    <style>
+      {{ leaflet_css | safe }}
+    </style>
+    <script type="text/javascript">
+      {{ leaflet_js | safe }}
+    </script>
     <style>
       div.plan_summary span {
         display: inline-block;


### PR DESCRIPTION
## Overview

Embeds Leaflet directly into the plan submission single-page report, so that it doesn't have to be hosted anywhere for the page to work. The page is now fully self-contained except for map tiles.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

 * Follow the instructions from https://github.com/azavea/district-builder-dtl-pa/pull/36 to get a plan submission HTML report.
 * Verify that the new HTML report embeds Leaflet.js and leaflet.css in the document rather than linking to them (and that it renders correctly, obviously).
