### PR TITLE
Rework config for info popup display

### DIFF
--- a/django/publicmapping/config/config.xml
+++ b/django/publicmapping/config/config.xml
@@ -24,16 +24,16 @@
     <Subjects>
         <Subject id="poptot" field="TOTAL_POP" name="Total Population"
                  short_name="Total Pop." displayed="true" sortkey="1" default="true" />
-        <Subject id="pophisp" field="HISPANIC" name="Total Hispanic/Latino Population"
-                 short_name="Hispanic" displayed="false" sortkey="2" />
         <Subject id="popwnh" field="WHITE_NH" name="Total White Population"
-                 short_name="White" displayed="false" sortkey="3" />
+                 short_name="White" displayed="false" sortkey="2" />
         <Subject id="popblk" field="BLACK_NH" name="Total Black Population"
-                 short_name="Black" displayed="false" sortkey="4" />
-        <Subject id="popnam" field="AI_AN_NH" name="Total American Indian/Alaskan Native"
-                 short_name="Nat Amer" displayed="false" sortkey="5" />
+                 short_name="Black" displayed="false" sortkey="3" />
+        <Subject id="pophisp" field="HISPANIC" name="Total Hispanic/Latino Population"
+                 short_name="Hispanic" displayed="false" sortkey="4" />
         <Subject id="popasn" field="ASIAN_NH" name="Total Asian Population"
-                 short_name="As Amer" displayed="false" sortkey="6" />
+                 short_name="As Amer" displayed="false" sortkey="5" />
+        <Subject id="popnam" field="AI_AN_NH" name="Total American Indian/Alaskan Native"
+                 short_name="Nat Amer" displayed="false" sortkey="6" />        
         <Subject id="poppild" field="HAW_OPI_NH" name="Total Native Hawaiian/Pacific Islander"
                  short_name="Pac Isldr" displayed="false" sortkey="7" />
         <Subject id="popoth" field="OTHER_NH" name="Total Other Race"

--- a/django/publicmapping/redistricting/views.py
+++ b/django/publicmapping/redistricting/views.py
@@ -497,7 +497,7 @@ def commonplan(request, planid):
         reporting_template = None
         tags = []
         calculator_reports = []
-    demos = Subject.objects.all().order_by('sort_key')[0:3]
+    demos = Subject.objects.all().order_by('sort_key')[0:5]
     layers = []
     snaplayers = []
 

--- a/django/publicmapping/static/js/mapping.js
+++ b/django/publicmapping/static/js/mapping.js
@@ -1788,8 +1788,19 @@ function mapinit(srs,maxExtent) {
                 // Clear out the map tip div
                 $(tipdiv).find('.demographic').remove();
 
+                // Hard-code sort order for characteristics
+                var CHARACTERISTICS_SORT_ORDER = [
+                    "Total Pop.",
+                    "White",
+                    "Black",
+                    "Hispanic",
+                    "As Amer"
+                ];
                 // sort the characteristics alphabetically by label
-                ctics = $(ctics).sort(function(a, b) { return a.lbl > b.lbl; });
+                ctics = $(ctics).sort(function(a, b) {
+                    return CHARACTERISTICS_SORT_ORDER.indexOf(a.lbl) >
+                        CHARACTERISTICS_SORT_ORDER.indexOf(b.lbl);
+                });
 
                 // truncate the breadcrumbs into a single string
                 var place = [];

--- a/scripts/update
+++ b/scripts/update
@@ -30,7 +30,7 @@ function run_migrations() {
 function reconfigure() {
     echo "Reconfigure"
     docker-compose \
-        exec -T django ./manage.py setup config/config.xml
+        exec -T django ./manage.py setup config/config.xml -f
 }
 
 function write_settings() {


### PR DESCRIPTION
## Overview

C70 requested changes to the display of the info popup.  They would like to display the 5 following demographic data points:

Total Population
Total White Population
Total Black Population
Total Hispanic/Latino Population
Total Asian Population

This PR makes changes to `views.py` and `config.xml` to reorder the demographic Subjects and increase the number of elements listed on the info popup to include the ones they want.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

### Notes

I made changes in what I believe to be the appropriate places to make this happen based on Kenny's message in #district-builder.  However I don't have a development environment to test these changes. I'm hoping this small change can save some developer time doing it, so I would like someone to test this out and see if the changes work. If it doesn't end up just working, I'll create a task in PivotalTracker for someone to take.

## Testing Instructions

 * With the app running on this branch, login and go to a plan
 * Click the info button and click a shape on the map
 * The 5 Subjects listed in the description above should be visible
