### PR TITLE
Fix translations by reconfiguring on update #158341090

### DIFF
--- a/scripts/update
+++ b/scripts/update
@@ -27,6 +27,12 @@ function run_migrations() {
         exec -T django ./manage.py migrate
 }
 
+function reconfigure() {
+    echo "Reconfigure"
+    docker-compose \
+        exec -T django ./manage.py setup config/config.xml
+}
+
 function write_settings() {
     # Write config_settings to the filesystem so it doesn't get
     # overwritten by docker-compose volume mounts
@@ -67,6 +73,7 @@ then
         write_settings
         docker-compose up -d "${MIGRATION_CONTAINERS[@]}"
         run_migrations
+        reconfigure
         change_geoserver_admin_password
     fi
     exit


### PR DESCRIPTION
## Overview

Reconfigure on update.

This will cause translations in `config.xml` to be regenerated whenever we deploy.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

First let's get to the state where staging is at, then we'll fix it.

* Turn off `vagrant rsync-auto` if running
* Check out the commit prior to the one where translations were fixed (bebecba)
* `vagrant reload` to make the changes to _not_ exclude the `xmlconfig.po` files take effect
* `./script/server`
* Visit http://localhost:8080/districtmapping/plan/2/view/ and notice that the translations in the metrics pane to the right are broken
* Check out this branch
* `vagrant reload` again (`xmlconfig.po` is now excluded and won't overwrite what's in the VM/container)
* Run `./scripts/server` and make sure the translations are still broken

Now we are in the state staging is at. Let's fix it by running:

* `./scripts/update`
* `./scripts/server`

These are the same commands that are run when we deploy (see https://github.com/azavea/district-builder-dtl-pa/blob/develop/scripts/infra#L86-L87) so this should fix it.

Closes #158341090
