### PR TITLE
Add district labels to submission report map

### DIFF
--- a/django/publicmapping/redistricting/management/commands/submission_report.py
+++ b/django/publicmapping/redistricting/management/commands/submission_report.py
@@ -40,8 +40,12 @@ class Command(BaseCommand):
         scores_html = score_panel.render(submission.plan)
         GeoJSONSerializer = serializers.get_serializer('geojson')
         serializer = GeoJSONSerializer()
+        # is_unassigned is a property so we can't use queryset filtering
+        # The unassigned district is a catch-all for geounits that haven't been assigned to a real
+        # district. We don't want to display this on the submission map, so filter it out here.
+        districts = [d for d in submission.plan.district_set.all() if not d.is_unassigned]
         geojson = serializer.serialize(
-            submission.plan.district_set.all(),
+            districts,
             geometry_field='geom',
             fields=('short_label', 'long_label')
         )

--- a/django/publicmapping/redistricting/templates/submission_summary.html
+++ b/django/publicmapping/redistricting/templates/submission_summary.html
@@ -56,7 +56,11 @@
       {{ submission.values_statement }}
     </div>
     <script type="text/javascript">
-      var layer = L.geoJSON({{ geojson|safe }});
+      var layer = L.geoJSON({{ geojson|safe }}, {
+        onEachFeature: function (feature, layer) {
+          layer.bindTooltip(feature.properties.short_label, {permanent: true});
+        }
+      });
     </script>
     <script type="text/javascript">
       var map = L.map('leaflet');


### PR DESCRIPTION
## Overview

Adds district labels to the submission report page. Also filters out the unassigned catch-all district since it was generating a confusing label.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

<img width="647" alt="screen shot 2018-06-21 at 9 10 54 am" src="https://user-images.githubusercontent.com/447977/41721098-082fdc54-7533-11e8-896d-411d12e1bca7.png">

## Testing Instructions

 * Same as #36 but each district on the map should have a label now.
 
Closes #158324032
