### PR TITLE
Add region to Submission report

### DIFF
--- a/django/publicmapping/redistricting/models.py
+++ b/django/publicmapping/redistricting/models.py
@@ -2869,6 +2869,93 @@ class PlanSubmission(models.Model):
     )
     values_statement = models.TextField(blank=True)
 
+    REGIONS = {
+        'Eastern': set([
+            'Bucks',
+            'Carbon',
+            'Chester',
+            'Delaware',
+            'Lackawanna',
+            'Lehigh',
+            'Luzerne',
+            'Monroe',
+            'Montgomery',
+            'Northampton',
+            'Philadelphia',
+            'Pike',
+            'Susquehanna',
+            'Wayne',
+            'Wyoming',
+        ]),
+        'Central': set([
+            'Adams',
+            'Bedford',
+            'Berks',
+            'Blair',
+            'Bradford',
+            'Cambria',
+            'Cameron',
+            'Centre',
+            'Clearfield',
+            'Clinton',
+            'Columbia',
+            'Cumberland',
+            'Dauphin',
+            'Elk',
+            'Franklin',
+            'Fulton',
+            'Huntingdon',
+            'Indiana',
+            'Jefferson',
+            'Juniata',
+            'Lancaster',
+            'Lebanon',
+            'Lycoming',
+            'McKean',
+            'Mifflin',
+            'Montour',
+            'Northumberland',
+            'Perry',
+            'Potter',
+            'Shuylkill',
+            'Snyder',
+            'Somerset',
+            'Sullivan',
+            'Tioga',
+            'Union',
+            'York',
+        ]),
+        'Western': set([
+            'Allegheny',
+            'Armstrong',
+            'Beaver',
+            'Butler',
+            'Clarion',
+            'Crawford',
+            'Erie',
+            'Fayette',
+            'Forest',
+            'Greene',
+            'Lawrence',
+            'Mercer',
+            'Venango',
+            'Warren',
+            'Washington',
+            'Westmoreland',
+        ]),
+    }
+
+    @property
+    def region(self):
+        for region in self.REGIONS.keys():
+            if self.county in self.REGIONS[region]:
+                return region
+        # The current most likely use case for this is in a batch process that exports submission
+        # reports, so instead of risking that plan breaking if a bad county sneaks in, just continue
+        # and echo the county so we still get usable data out.
+        print('Warning: Unknown county {} encountered'.format(self.county))
+        return 'Unknown ({})'.format(self.county)
+
 
 class PlanSubmissionForm(ModelForm):
     class Meta:

--- a/django/publicmapping/redistricting/templates/editplan.html
+++ b/django/publicmapping/redistricting/templates/editplan.html
@@ -351,7 +351,77 @@
             </tr>
             <tr>
                 <td class="fname">{% trans "County" %} *</td>
-                <td><input name="county" class="field required" maxlength="50" /></td>
+                <td>
+                    <select name="county" class="field required" maxlength="50">
+                        <option value="Adams">Adams</option>
+                        <option value="Allegheny">Allegheny</option>
+                        <option value="Armstrong">Armstrong</option>
+                        <option value="Beaver">Beaver</option>
+                        <option value="Bedford">Bedford</option>
+                        <option value="Berks">Berks</option>
+                        <option value="Blair">Blair</option>
+                        <option value="Bradford">Bradford</option>
+                        <option value="Bucks">Bucks</option>
+                        <option value="Butler">Butler</option>
+                        <option value="Cambria">Cambria</option>
+                        <option value="Cameron">Cameron</option>
+                        <option value="Carbon">Carbon</option>
+                        <option value="Centre">Centre</option>
+                        <option value="Chester">Chester</option>
+                        <option value="Clarion">Clarion</option>
+                        <option value="Clearfield">Clearfield</option>
+                        <option value="Clinton">Clinton</option>
+                        <option value="Columbia">Columbia</option>
+                        <option value="Crawford">Crawford</option>
+                        <option value="Cumberland">Cumberland</option>
+                        <option value="Dauphin">Dauphin</option>
+                        <option value="Delaware">Delaware</option>
+                        <option value="Elk">Elk</option>
+                        <option value="Erie">Erie</option>
+                        <option value="Fayette">Fayette</option>
+                        <option value="Forest">Forest</option>
+                        <option value="Franklin">Franklin</option>
+                        <option value="Fulton">Fulton</option>
+                        <option value="Greene">Greene</option>
+                        <option value="Huntingdon">Huntingdon</option>
+                        <option value="Indiana">Indiana</option>
+                        <option value="Jefferson">Jefferson</option>
+                        <option value="Juniata">Juniata</option>
+                        <option value="Lackawanna">Lackawanna</option>
+                        <option value="Lancaster">Lancaster</option>
+                        <option value="Lawrence">Lawrence</option>
+                        <option value="Lebanon">Lebanon</option>
+                        <option value="Lehigh">Lehigh</option>
+                        <option value="Luzerne">Luzerne</option>
+                        <option value="Lycoming">Lycoming</option>
+                        <option value="McKean">McKean</option>
+                        <option value="Mercer">Mercer</option>
+                        <option value="Mifflin">Mifflin</option>
+                        <option value="Monroe">Monroe</option>
+                        <option value="Montgomery">Montgomery</option>
+                        <option value="Montour">Montour</option>
+                        <option value="Northampton">Northampton</option>
+                        <option value="Northumberland">Northumberland</option>
+                        <option value="Perry">Perry</option>
+                        <option value="Philadelphia">Philadelphia</option>
+                        <option value="Pike">Pike</option>
+                        <option value="Potter">Potter</option>
+                        <option value="Shuylkill">Shuylkill</option>
+                        <option value="Snyder">Snyder</option>
+                        <option value="Somerset">Somerset</option>
+                        <option value="Sullivan">Sullivan</option>
+                        <option value="Susquehanna">Susquehanna</option>
+                        <option value="Tioga">Tioga</option>
+                        <option value="Union">Union</option>
+                        <option value="Venango">Venango</option>
+                        <option value="Warren">Warren</option>
+                        <option value="Washington">Washington</option>
+                        <option value="Wayne">Wayne</option>
+                        <option value="Westmoreland">Westmoreland</option>
+                        <option value="Wyoming">Wyoming</option>
+                        <option value="York">York</option>
+                    </select>
+                </td>
             </tr>
             <tr>
                 <td class="fname">{% trans "Zip code" %} *</td>

--- a/django/publicmapping/redistricting/templates/submission_summary.html
+++ b/django/publicmapping/redistricting/templates/submission_summary.html
@@ -31,6 +31,7 @@
   <body>
     <h1>Draw The Lines PA</h1>
     <h2>Submission Details</h2>
+    <div class="region">Region: {{ submission.region }}</div>
     <div class="division">Division: {{ submission.get_contest_division_display }}</div>
     <div class="plan-name">Map name: {{ submission.submitted_plan_name }}</div>
     <div class="contestant-name">Contestant name: {{ submission.first_name }} {{ submission.last_name }}</div>


### PR DESCRIPTION
## Overview

Calculates and displays a plan submission's region, according to the region breakdown given to us by C70. As part of this, changes the County item in the submission form from a text input to a dropdown.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

<img width="227" alt="screen shot 2018-06-21 at 1 45 15 pm" src="https://user-images.githubusercontent.com/447977/41736061-61705584-7559-11e8-8eeb-6b9ec8f3bd3a.png">

### Notes

I could have made this more robust by adding a `choices` parameter to the `county` field of `PlanSubmission`. In the interest of time, I opted to skip that, so the only validation is from the dropdown in the UI. If someone uses an HTTP client to submit plans directly to the API endpoint and inputs bogus county names, the worst that could happen is that the region will show up as "Unknown (county name)" in the report.

## Testing Instructions

 * Same as #36 but do it a few different times with counties from different parts of the state and verify that the region shows up as Western, Central, or Eastern appropriately.

Closes #158265780
