### PR TITLE
Change app server instance type from t2.small to m5.large #158013676

### DIFF
--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -13,7 +13,7 @@ variable "aws_region" {
 }
 
 variable "app_server_instance_type" {
-  default = "t2.small"
+  default = "m5.large"
 }
 
 variable "ssl_certificate_arn" {}


### PR DESCRIPTION
## Overview

Change app server instance type from t2.small to m5.large to improve performance

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

Closes #158013676
