### PR TITLE
Show number of majority-minority districts in side bar #158613616

### DIFF
--- a/django/publicmapping/config/config.xml
+++ b/django/publicmapping/config/config.xml
@@ -181,6 +181,14 @@
                 <Argument name="threshold" value="0.5" />
             </ScoreFunction>
 
+            <ScoreFunction id="district_vapnownh_thresh" type="district"
+                calculator="redistricting.calculators.Threshold"
+                label="Non-white VAP Threshold">
+                <ScoreArgument name="value" ref="district_vapwnh_percent" />
+                <Argument name="threshold" value="0.5" />
+                <Argument name="less_than" value="1" />
+            </ScoreFunction>
+
             <ScoreFunction id="district_vapnam_percent" type="district"
                 calculator="redistricting.calculators.Percent"
                 label="Nat. Amer. VAP">
@@ -406,6 +414,13 @@
                 <SubjectArgument name="republican" ref="voterep" />
             </ScoreFunction>
 
+            <ScoreFunction id="congress_plan_vapnownh_thresh" type="plan"
+                calculator="redistricting.calculators.SumValues"
+                label="Majority-Minority">
+                <ScoreArgument name="value1" ref="district_vapnownh_thresh" />
+                <Argument name="target" value="18"/>
+            </ScoreFunction>
+
             <ScoreFunction id="congress_plan_polsbypopper" type="plan"
                 calculator="redistricting.calculators.PolsbyPopper"
                 label="Average Compactness"
@@ -510,6 +525,7 @@
                 <Score ref="congress_plan_polsbypopper"/>
                 <Score ref="congress_plan_equivalence"/>
                 <Score ref="congress_plan_competitiveness"/>
+                <Score ref="congress_plan_vapnownh_thresh"/>
             </ScorePanel>
 
             <!-- Basic Information -->


### PR DESCRIPTION
## Overview

Show number of majority-minority districts in side bar.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

### Screenshot

![minority-majority_fixed](https://user-images.githubusercontent.com/2926237/42114211-3623f2c8-7bbc-11e8-906a-0241b7cec69f.png)

### Notes

An issue with the shapefile was identified and subsequently fixed while working on this feature. The `TOT18O_POP` field was not actually total VAP but total _non-hispanic_ VAP. A change was made to add `O18HISPAN` to the value in this field to get the true total VAP.

## Testing Instructions

* `./scripts/configure_pa_data && ./scripts/server`
* Select "Demographics" from the dropdown in the side bar and make sure the percentages for "Asian VAP", "Black VAP", and "Hisp. VAP" make sense relative to the "Majority-Minority" count.

Closes #158613616
