### PR TITLE
Update links and buttons on header

### DIFF
--- a/django/publicmapping/publicmapping/templates/index.html
+++ b/django/publicmapping/publicmapping/templates/index.html
@@ -98,11 +98,7 @@
           <li><a href="">item</a></li>
        -->
           <li><a href="https://drawthelinespa.org/about/">{% trans "About" %}</a></li>
-          <li>
-            <a class="last" href="mailto:support@districtbuilder.org?subject=%5BDistrictBuilder%5D%20Support%20Request">
-              {% trans "Support" %}
-            </a>
-          </li>
+          <li><a href="https://drawthelinespa.org/">{% trans "Support" %}</a></li>
           <li>
             {% include "language_chooser.html" %}
           </li>

--- a/django/publicmapping/publicmapping/templates/index.html
+++ b/django/publicmapping/publicmapping/templates/index.html
@@ -97,7 +97,7 @@
         <!--
           <li><a href="">item</a></li>
        -->
-          <li><a href="http://www.publicmapping.org">{% trans "About" %}</a></li>
+          <li><a href="https://drawthelinespa.org/about/">{% trans "About" %}</a></li>
           <li>
             <a class="last" href="mailto:support@districtbuilder.org?subject=%5BDistrictBuilder%5D%20Support%20Request">
               {% trans "Support" %}
@@ -126,7 +126,7 @@
           </ul>
           <h3>{% trans "About this DistrictBuilder instance" %}</h3>
           <ul>
-            <li><a href="#">{% trans "About this DistrictBuilder instance" %}</a></li>
+            <li><a href="https://drawthelinespa.org/about/">{% trans "About this DistrictBuilder instance" %}</a></li>
           </ul>
         </div>
 

--- a/django/publicmapping/publicmapping/templates/language_chooser.html
+++ b/django/publicmapping/publicmapping/templates/language_chooser.html
@@ -28,6 +28,7 @@
 {% load redistricting_extras %}
 {% load i18n %}
 
+{% comment %}
 <div id="language_menu_wrapper" class="toggle_menu_wrapper" >
     <div id="language_menu_target" class="toggle_menu_target" >
         {% trans "Language" %}
@@ -44,3 +45,4 @@
         {% endfor %}
     </div>
 </div>
+{% endcomment %}

--- a/django/publicmapping/redistricting/templates/viewplan.html
+++ b/django/publicmapping/redistricting/templates/viewplan.html
@@ -251,6 +251,7 @@
             If the user is anonymous, display a login link.
 
             {% endcomment %}
+            <li><a href="https://drawthelinespa.org/">{% trans "Support" %}</a></li>
             <li><a class="last" href="/">{% trans "Login" %}</a></li>
             {% else %}
             {% comment %}
@@ -259,6 +260,7 @@
             management panel, and a logout link.
 
             {% endcomment %}
+            <li><a href="https://drawthelinespa.org/">{% trans "Support" %}</a></li>
             <li><a href="#" onclick="$('#register').dialog('open');return false;">{% trans "My Account" %}</a></li>
             <li><a class="last" href="/accounts/logout/">{% trans "Logout" %}</a></li>
             {% endif %}


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed.

- [x] Remove the language picker on all pages
- [x] Make the About button link to `https://drawthelinespa.org/about/`
- [x] Make the Support button link to `[placeholder]`
- [x] Make sure the Support button is present on all pages

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Note

The support link is currently a placeholder (`https://drawthelinespa.org/`). To change it, we need to edit that link on `django/publicmapping/publicmapping/templates/index.html` and `django/publicmapping/redistricting/templates/viewplan.html`.

## Testing Instructions

 * Checkout branch, `./scripts/server`, check if the 4 items above look good.
