### PR TITLE
Fix translations issues

### DIFF
--- a/django/publicmapping/locale/en/LC_MESSAGES/django.po
+++ b/django/publicmapping/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-06 10:32-0400\n"
+"POT-Creation-Date: 2018-07-06 12:21-0400\n"
 "PO-Revision-Date: 2012-11-06 16:01-0600\n"
 "Last-Translator: David Zwarg <dzwarg@azavea.com>\n"
 "Language-Team: Azavea <info@azavea.com>\n"
@@ -117,7 +117,7 @@ msgid "Sign Up"
 msgstr ""
 
 #: publicmapping/templates/account.html:98
-#: redistricting/templates/editplan.html:400
+#: redistricting/templates/editplan.html:470
 msgid "Indicates required field"
 msgstr ""
 
@@ -382,6 +382,37 @@ msgstr ""
 
 #: publicmapping/templates/admin/redistricting/subject/upload_form.html:160
 msgid "Upload"
+msgstr ""
+
+#: publicmapping/templates/forgottenpassword.email:12
+#: redistricting/templates/error.email:15
+#: redistricting/templates/importedplan.email:16
+#: redistricting/templates/submitted.email:12
+msgid "Hello"
+msgstr ""
+
+#: publicmapping/templates/forgottenpassword.email:14
+msgid ""
+"You requested a new password for the Public Mapping Project. Sorry for the "
+"inconvenience!  This is your new password"
+msgstr ""
+
+#: publicmapping/templates/forgottenpassword.email:16
+msgid "Thank you for using the Public Mapping Project."
+msgstr ""
+
+#: publicmapping/templates/forgottenpassword.email:18
+#: redistricting/templates/error.email:25
+#: redistricting/templates/importedplan.email:28
+#: redistricting/templates/submitted.email:16
+msgid "Happy Redistricting!"
+msgstr ""
+
+#: publicmapping/templates/forgottenpassword.email:19
+#: redistricting/templates/error.email:26
+#: redistricting/templates/importedplan.email:29
+#: redistricting/templates/submitted.email:17
+msgid "The Public Mapping Team"
 msgstr ""
 
 #: publicmapping/templates/index.html:44
@@ -777,7 +808,7 @@ msgstr ""
 
 #: redistricting/admin.py:499
 msgid "No task with that id."
-msgstr ""
+msgstr "No task with that id."
 
 #: redistricting/calculators.py:120 redistricting/calculators.py:298
 #: redistricting/calculators.py:364 redistricting/calculators.py:611
@@ -912,32 +943,32 @@ msgid ""
 "locked."
 msgstr ""
 
-#: redistricting/models.py:3450
+#: redistricting/models.py:3538
 msgid "Unassigned"
 msgstr ""
 
-#: redistricting/reportcalculators.py:53
-#: redistricting/reportcalculators.py:109
-#: redistricting/reportcalculators.py:141
+#: redistricting/reportcalculators.py:59
+#: redistricting/reportcalculators.py:117
+#: redistricting/reportcalculators.py:149
 msgid "DistrictID"
 msgstr ""
 
-#: redistricting/reportcalculators.py:57
-#: redistricting/reportcalculators.py:145
+#: redistricting/reportcalculators.py:63
+#: redistricting/reportcalculators.py:153
 #: redistricting/templates/basic_information.html:71
 msgid "Population"
 msgstr ""
 
-#: redistricting/reportcalculators.py:74
+#: redistricting/reportcalculators.py:80
 msgid "Within Target Range"
 msgstr ""
 
-#: redistricting/reportcalculators.py:113
+#: redistricting/reportcalculators.py:121
 #: redistricting/templates/viewplan.html:1043
 msgid "Compactness"
 msgstr ""
 
-#: redistricting/reportcalculators.py:150
+#: redistricting/reportcalculators.py:158
 msgid "Proportion"
 msgstr ""
 
@@ -989,7 +1020,7 @@ msgstr ""
 msgid "Competition submission (user: %(username)s, planid: %(plan_id)d)"
 msgstr ""
 
-#: redistricting/tasks.py:685 redistricting/views.py:2157
+#: redistricting/tasks.py:685 redistricting/views.py:2159
 msgid "Plan submitted successfully"
 msgstr "Map submitted successfully"
 
@@ -1054,6 +1085,39 @@ msgstr ""
 #: redistricting/tasks.py:1916
 #, python-format
 msgid "Upload complete. Subject \"%(subject_name)s\" added."
+msgstr ""
+
+#: redistricting/templates/admin.email:17
+msgid "Hello Admin"
+msgstr ""
+
+#: redistricting/templates/admin.email:19
+msgid "There was a problem importing a plan file from user"
+msgstr "There was a problem importing a map file from user"
+
+#: redistricting/templates/admin.email:19
+msgid ""
+"This user attempted to upload a file containing a plan but had some "
+"trouble.  The plan may have been imported."
+msgstr ""
+"This user attempted to upload a file containing a map but had some trouble.  "
+"The map may have been imported."
+
+#: redistricting/templates/admin.email:22
+#: redistricting/templates/leaderboard_panel_all.html:46
+#: redistricting/templates/leaderboard_panel_mine.html:44
+#: redistricting/templates/submission.email:15
+msgid "Plan Name"
+msgstr "Map Name"
+
+#: redistricting/templates/admin.email:32
+msgid ""
+"If the user continues to have problems with this process, please check the "
+"application settings."
+msgstr ""
+
+#: redistricting/templates/admin.email:34
+msgid "Thank you."
 msgstr ""
 
 #: redistricting/templates/basic_information.html:44
@@ -1290,7 +1354,7 @@ msgstr ""
 "filling out this form."
 
 #: redistricting/templates/editplan.html:156
-#: redistricting/templates/editplan.html:396
+#: redistricting/templates/editplan.html:466
 msgid "Submit Final Plan"
 msgstr "Submit Final Map"
 
@@ -1356,9 +1420,9 @@ msgid ""
 msgstr ""
 "In order to be considered for placement on the leaderboards your map must "
 "meet the criteria for creating a legal redistricting map. Keep in mind that "
-"as soon as you edit a verified map, it will automatically become "
-"\"unverified\" and you will need to re-verify it in order for it to again be "
-"considered for the leaderboards."
+"as soon as you edit a verified map, it will automatically become \"unverified"
+"\" and you will need to re-verify it in order for it to again be considered "
+"for the leaderboards."
 
 #: redistricting/templates/editplan.html:185
 msgid ""
@@ -1408,8 +1472,7 @@ msgstr ""
 "Choose districts to paste into your map.  A map has a maximum number of "
 "districts allowed by law.  If you would like to paste districts into a map, "
 "you must have fewer districts in your map than the maximum allowed.  If you "
-"would like to remove districts from your map, use the district unassign "
-"tool."
+"would like to remove districts from your map, use the district unassign tool."
 
 #: redistricting/templates/editplan.html:212
 #, python-format
@@ -1496,27 +1559,27 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: redistricting/templates/editplan.html:359
+#: redistricting/templates/editplan.html:429
 msgid "Zip code"
 msgstr ""
 
-#: redistricting/templates/editplan.html:363
+#: redistricting/templates/editplan.html:433
 msgid "Contest division"
 msgstr ""
 
-#: redistricting/templates/editplan.html:366
+#: redistricting/templates/editplan.html:436
 msgid "Youth (Grades 5-12)"
 msgstr ""
 
-#: redistricting/templates/editplan.html:367
+#: redistricting/templates/editplan.html:437
 msgid "Higher Ed (Undergraduate, Graduate, Professional)"
 msgstr ""
 
-#: redistricting/templates/editplan.html:368
+#: redistricting/templates/editplan.html:438
 msgid "Adult (Non-student)"
 msgstr ""
 
-#: redistricting/templates/editplan.html:374
+#: redistricting/templates/editplan.html:444
 msgid ""
 "Values &ndash; tell us what values, considerations and trade-offs you made "
 "in your plan:"
@@ -1524,7 +1587,7 @@ msgstr ""
 "Values &ndash; tell us what values, considerations and trade-offs you made "
 "in your map:"
 
-#: redistricting/templates/editplan.html:384
+#: redistricting/templates/editplan.html:454
 msgid ""
 "\n"
 "                    By submitting a plan for consideration, you are "
@@ -1538,8 +1601,7 @@ msgid ""
 "                    "
 msgstr ""
 "\n"
-"                    By submitting a map for consideration, you are "
-"agreeing\n"
+"                    By submitting a map for consideration, you are agreeing\n"
 "                    to have your map published in local news media outlets\n"
 "                    and have it presented to a legislative body. Unless\n"
 "                    you request otherwise, the project partners will "
@@ -1548,32 +1610,58 @@ msgstr ""
 "                    map whenever feasible.\n"
 "                    "
 
-#: redistricting/templates/editplan.html:418
+#: redistricting/templates/editplan.html:488
 msgid "Community Info"
 msgstr ""
 
-#: redistricting/templates/editplan.html:419
+#: redistricting/templates/editplan.html:489
 msgid "0"
 msgstr ""
 
-#: redistricting/templates/editplan.html:423
+#: redistricting/templates/editplan.html:493
 msgid "1. Edit Community Label:"
 msgstr ""
 
-#: redistricting/templates/editplan.html:430
+#: redistricting/templates/editplan.html:500
 msgid "2. Edit Community Type:"
 msgstr ""
 
-#: redistricting/templates/editplan.html:441
+#: redistricting/templates/editplan.html:511
 msgid "3. Comments:"
 msgstr ""
 
-#: redistricting/templates/editplan.html:449
+#: redistricting/templates/editplan.html:519
 msgid "Oops!"
 msgstr ""
 
-#: redistricting/templates/editplan.html:450
+#: redistricting/templates/editplan.html:520
 msgid "Sorry, your information could not be saved. Please try again later."
+msgstr ""
+
+#: redistricting/templates/error.email:17
+msgid ""
+"We apologize for the inconvenience, but your uploaded file was not converted "
+"into a plan. There are a few reasons why this might have happened. As best "
+"we can tell, your file failed to upload for the following reason:"
+msgstr ""
+"We apologize for the inconvenience, but your uploaded file was not converted "
+"into a map. There are a few reasons why this might have happened. As best we "
+"can tell, your file failed to upload for the following reason:"
+
+#: redistricting/templates/error.email:23
+msgid "If you correct this issue and upload your file again, we can try again."
+msgstr ""
+
+#: redistricting/templates/importedplan.email:18
+msgid ""
+"Your plan was created successfully. You can view, edit, and share your new "
+"plan by logging in to DistrictBuilder, and pulling up the plan entitled"
+msgstr ""
+"Your map was created successfully. You can view, edit, and share your new "
+"map by logging in to DistrictBuilder, and pulling up the map entitled"
+
+#: redistricting/templates/importedplan.email:21
+msgid "There were a few errors during import:"
 msgstr ""
 
 #: redistricting/templates/leaderboard_panel_all.html:38
@@ -1584,11 +1672,6 @@ msgstr ""
 #: redistricting/templates/leaderboard_panel_mine.html:42
 msgid "Rank"
 msgstr ""
-
-#: redistricting/templates/leaderboard_panel_all.html:46
-#: redistricting/templates/leaderboard_panel_mine.html:44
-msgid "Plan Name"
-msgstr "Map Name"
 
 #: redistricting/templates/leaderboard_panel_all.html:47
 #: redistricting/templates/leaderboard_panel_mine.html:45
@@ -1702,6 +1785,30 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
+#: redistricting/templates/submission.email:12
+msgid "user name"
+msgstr ""
+
+#: redistricting/templates/submission.email:13
+msgid "Plan id"
+msgstr "Map id"
+
+#: redistricting/templates/submission.email:14
+msgid "Plan version"
+msgstr "Map version"
+
+#: redistricting/templates/submission.email:16
+msgid "legislative body"
+msgstr ""
+
+#: redistricting/templates/submitted.email:14
+msgid "Your Plan"
+msgstr "Your Map"
+
+#: redistricting/templates/submitted.email:14
+msgid "has been successfully submitted. Thank you for your submission."
+msgstr ""
+
 #: redistricting/templates/viewplan.html:41
 msgid "DistrictBuilder redistricting plan: "
 msgstr "DistrictBuilder redistricting map: "
@@ -1791,6 +1898,7 @@ msgstr ""
 msgid ""
 "You must choose a legislative body to which the new plan will be applied."
 msgstr ""
+"You must choose a legislative body to which the new map will be applied."
 
 #: redistricting/templates/viewplan.html:339
 msgid "Select a body"
@@ -2283,13 +2391,13 @@ msgstr "User %(user)s doesn't have permission to unload this map"
 #: redistricting/views.py:292
 #, python-format
 msgid "User %(username)s doesn't have permission to copy this model"
-msgstr ""
+msgstr "User %(username)s doesn't have permission to copy this model"
 
 #: redistricting/views.py:308
 msgid "You already have a plan named that. Please pick a unique name."
 msgstr "You already have a map named that. Please pick a unique name."
 
-#: redistricting/views.py:336 redistricting/views.py:2130
+#: redistricting/views.py:336 redistricting/views.py:2131
 msgid "Could not save district copies"
 msgstr ""
 
@@ -2313,346 +2421,346 @@ msgstr "map"
 msgid "Couldn't save new plan"
 msgstr "Couldn't save new map"
 
-#: redistricting/views.py:1018 redistricting/views.py:1219
-#: redistricting/views.py:1285 redistricting/views.py:1358
-#: redistricting/views.py:1421 redistricting/views.py:1469
+#: redistricting/views.py:1019 redistricting/views.py:1220
+#: redistricting/views.py:1286 redistricting/views.py:1359
+#: redistricting/views.py:1422 redistricting/views.py:1470
 msgid "No plan with the given id"
 msgstr "No map with the given id"
 
-#: redistricting/views.py:1023 redistricting/views.py:1474
-#: redistricting/views.py:1489
+#: redistricting/views.py:1024 redistricting/views.py:1475
+#: redistricting/views.py:1490
 msgid "User can't view the given plan"
 msgstr "User can't view the given map"
 
-#: redistricting/views.py:1028
+#: redistricting/views.py:1029
 msgid "Information for report wasn't sent via POST"
 msgstr ""
 
-#: redistricting/views.py:1046
+#: redistricting/views.py:1047
 msgid "Plan report is ready."
 msgstr "Map report is ready."
 
-#: redistricting/views.py:1054
+#: redistricting/views.py:1055
 msgid "Report is building."
 msgstr ""
 
-#: redistricting/views.py:1062
+#: redistricting/views.py:1063
 msgid "Report generation started."
 msgstr ""
 
-#: redistricting/views.py:1072
+#: redistricting/views.py:1073
 msgid "Unrecognized status when checking report status."
 msgstr ""
 
-#: redistricting/views.py:1179
+#: redistricting/views.py:1180
 msgid "Created 1 new district"
 msgstr ""
 
-#: redistricting/views.py:1185
+#: redistricting/views.py:1186
 msgid "Reached Max districts already"
 msgstr ""
 
-#: redistricting/views.py:1189
+#: redistricting/views.py:1190
 msgid "Couldn't save new district."
-msgstr ""
+msgstr "Couldn't save new district."
 
-#: redistricting/views.py:1191
+#: redistricting/views.py:1192
 msgid "Must specify name, geolevel, and geounit ids for new district."
 msgstr ""
 
-#: redistricting/views.py:1224 redistricting/views.py:1290
-#: redistricting/views.py:1363 redistricting/views.py:1426
+#: redistricting/views.py:1225 redistricting/views.py:1291
+#: redistricting/views.py:1364 redistricting/views.py:1427
 msgid "User can't edit the given plan"
 msgstr "User can't edit the given map"
 
-#: redistricting/views.py:1231
+#: redistricting/views.py:1232
 msgid "No districts selected to add to the given plan"
 msgstr "No districts selected to add to the given map"
 
-#: redistricting/views.py:1237
+#: redistricting/views.py:1238
 #, python-format
 msgid "Going to merge %(number_of_merged_districts)d districts"
 msgstr ""
 
-#: redistricting/views.py:1245
+#: redistricting/views.py:1246
 #, python-format
 msgid "Tried to merge too many districts; %(allowed_districts)d slots left"
 msgstr ""
 
-#: redistricting/views.py:1252
+#: redistricting/views.py:1253
 #, python-format
 msgid "Merged %(num_merged_districts)d districts"
 msgstr ""
 
-#: redistricting/views.py:1298
+#: redistricting/views.py:1299
 msgid "Multi-members not allowed for this legislative body"
 msgstr ""
 
-#: redistricting/views.py:1332
+#: redistricting/views.py:1333
 #, python-format
 msgid "Modified members for %(num_districts)d districts"
 msgstr ""
 
-#: redistricting/views.py:1389
+#: redistricting/views.py:1390
 msgid "Can't combine locked districts"
 msgstr ""
 
-#: redistricting/views.py:1398
+#: redistricting/views.py:1399
 msgid "Successfully combined districts"
 msgstr ""
 
-#: redistricting/views.py:1401
+#: redistricting/views.py:1402
 msgid "Could not combine districts"
 msgstr ""
 
-#: redistricting/views.py:1437
+#: redistricting/views.py:1438
 msgid "Could not fix unassigned"
 msgstr ""
 
-#: redistricting/views.py:1485
+#: redistricting/views.py:1486
 msgid "No other plan with the given id"
 msgstr "No other map with the given id"
 
-#: redistricting/views.py:1499
+#: redistricting/views.py:1500
 #, python-format
 msgid "othertype not supported: %(other)s"
 msgstr ""
 
-#: redistricting/views.py:1505 redistricting/views.py:1506
+#: redistricting/views.py:1506 redistricting/views.py:1507
 msgid "split"
 msgstr ""
 
-#: redistricting/views.py:1509
+#: redistricting/views.py:1510
 #, python-format
 msgid "Found %(num_splits)d %(split_word)s"
 msgstr ""
 
-#: redistricting/views.py:1515
+#: redistricting/views.py:1516
 msgid "Could not query for splits"
 msgstr ""
 
-#: redistricting/views.py:1529
+#: redistricting/views.py:1530
 msgid "No planIds provided"
 msgstr ""
 
-#: redistricting/views.py:1551
+#: redistricting/views.py:1552
 msgid "Plan does not exist."
 msgstr "Map does not exist."
 
-#: redistricting/views.py:1566
+#: redistricting/views.py:1567
 msgid "No layers were provided."
 msgstr ""
 
-#: redistricting/views.py:1627 redistricting/views.py:1647
+#: redistricting/views.py:1628 redistricting/views.py:1648
 msgid "Could not add units to district."
 msgstr ""
 
-#: redistricting/views.py:1639
+#: redistricting/views.py:1640
 #, python-format
 msgid "Updated %(num_fixed_districts)d districts"
 msgstr ""
 
-#: redistricting/views.py:1652
+#: redistricting/views.py:1653
 msgid "Geounits weren't found in a district."
 msgstr ""
 
-#: redistricting/views.py:1682
+#: redistricting/views.py:1683
 msgid "Must include lock parameter."
 msgstr ""
 
-#: redistricting/views.py:1684
+#: redistricting/views.py:1685
 msgid "Must include version parameter."
 msgstr ""
 
-#: redistricting/views.py:1692
+#: redistricting/views.py:1693
 msgid "Plan or district does not exist."
 msgstr "Map or district does not exist."
 
-#: redistricting/views.py:1702
+#: redistricting/views.py:1703
 #, python-format
 msgid "District successfully %(locked_state)s"
 msgstr ""
 
-#: redistricting/views.py:1703
+#: redistricting/views.py:1704
 msgid "locked"
 msgstr ""
 
-#: redistricting/views.py:1703
+#: redistricting/views.py:1704
 msgid "unlocked"
 msgstr ""
 
-#: redistricting/views.py:1762
+#: redistricting/views.py:1763
 msgid "No plan exists with that ID."
 msgstr "No map exists with that ID."
 
-#: redistricting/views.py:1830
+#: redistricting/views.py:1831
 msgid "Subject for districts is required."
 msgstr ""
 
-#: redistricting/views.py:1833
+#: redistricting/views.py:1834
 msgid "Query failed."
 msgstr ""
 
-#: redistricting/views.py:1940
+#: redistricting/views.py:1941
 msgid "Geometry is required."
 msgstr ""
 
-#: redistricting/views.py:1944
+#: redistricting/views.py:1945
 msgid "Invalid plan."
 msgstr "Invalid map."
 
-#: redistricting/views.py:1958
+#: redistricting/views.py:1959
 msgid "Couldn't get geography info from the server. No plan with the given id."
 msgstr "Couldn't get geography info from the server. No map with the given id."
 
-#: redistricting/views.py:1976
+#: redistricting/views.py:1977
 msgid "Unable to get Demographics ScoreDisplay"
 msgstr ""
 
-#: redistricting/views.py:1983
+#: redistricting/views.py:1984
 msgid "Unable to get Personalized ScoreDisplay"
 msgstr ""
 
-#: redistricting/views.py:1994
+#: redistricting/views.py:1995
 msgid "Couldn't render display tab."
 msgstr ""
 
-#: redistricting/views.py:2028
+#: redistricting/views.py:2029
 msgid "Failed to get file status"
 msgstr ""
 
-#: redistricting/views.py:2065
+#: redistricting/views.py:2066
 msgid "File is not yet ready. Please try again in a few minutes"
 msgstr ""
 
-#: redistricting/views.py:2091
+#: redistricting/views.py:2092
 msgid "Task submitted"
 msgstr ""
 
-#: redistricting/views.py:2115
+#: redistricting/views.py:2116
 msgid "Submission by: "
 msgstr ""
 
-#: redistricting/views.py:2200
+#: redistricting/views.py:2202
 msgid "No display configured"
 msgstr ""
 
-#: redistricting/views.py:2306
+#: redistricting/views.py:2308
 msgid "Unknown filter method."
 msgstr ""
 
-#: redistricting/views.py:2439
+#: redistricting/views.py:2441
 msgid "Must declare planId, name and description"
 msgstr ""
 
-#: redistricting/views.py:2452
+#: redistricting/views.py:2454
 msgid "Updated plan attributes"
 msgstr "Updated map attributes"
 
-#: redistricting/views.py:2454
+#: redistricting/views.py:2456
 msgid "Failed to save the changes to your plan"
 msgstr "Failed to save the changes to your map"
 
-#: redistricting/views.py:2459
+#: redistricting/views.py:2461
 msgid "Cannot edit a plan you don't own."
-msgstr ""
+msgstr "Cannot edit a map you don't own."
 
-#: redistricting/views.py:2476 redistricting/views.py:2509
+#: redistricting/views.py:2478 redistricting/views.py:2511
 msgid "Must declare planId"
 msgstr ""
 
-#: redistricting/views.py:2484
-msgid "Deleted plan"
-msgstr ""
-
 #: redistricting/views.py:2486
+msgid "Deleted plan"
+msgstr "Deleted map"
+
+#: redistricting/views.py:2488
 msgid "Failed to delete plan"
-msgstr ""
+msgstr "Failed to delete map"
 
-#: redistricting/views.py:2491
+#: redistricting/views.py:2493
 msgid "Cannot delete a plan you don't own."
-msgstr ""
-
-#: redistricting/views.py:2523
-msgid "Reaggregating plan"
-msgstr ""
+msgstr "Cannot delete a map you don't own."
 
 #: redistricting/views.py:2525
+msgid "Reaggregating plan"
+msgstr "Reaggregating map"
+
+#: redistricting/views.py:2527
 msgid "Failed to reaggregate plan"
-msgstr ""
+msgstr "Failed to reaggregate map"
 
-#: redistricting/views.py:2530
+#: redistricting/views.py:2532
 msgid "Cannot reaggregate a plan you don't own."
-msgstr ""
+msgstr "Cannot reaggregate a map you don't own."
 
-#: redistricting/views.py:2554
+#: redistricting/views.py:2556
 #, python-format
 msgid "Health retrieved at %(time)s\n"
 msgstr ""
 
-#: redistricting/views.py:2555
+#: redistricting/views.py:2557
 #, python-format
 msgid "%(plan_count)d plans in database\n"
-msgstr ""
+msgstr "%(plan_count)d maps in database\n"
 
-#: redistricting/views.py:2557
+#: redistricting/views.py:2559
 #, python-format
 msgid "%(session_count)d sessions in use out of %(session_limit)s\n"
 msgstr ""
 
-#: redistricting/views.py:2560
+#: redistricting/views.py:2562
 #, python-format
 msgid "%(num_users)d active users over the last 10 minutes\n"
 msgstr ""
 
-#: redistricting/views.py:2563
+#: redistricting/views.py:2565
 #, python-format
 msgid "%(mb_free)s MB of disk space free\n"
 msgstr ""
 
-#: redistricting/views.py:2565
+#: redistricting/views.py:2567
 #, python-format
 msgid ""
 "Memory Usage:\n"
 "%(mem_free)s\n"
 msgstr ""
 
-#: redistricting/views.py:2570
+#: redistricting/views.py:2572
 #, python-format
 msgid ""
 "ERROR! Couldn't get health:\n"
 "%s"
 msgstr ""
 
-#: redistricting/views.py:2578
+#: redistricting/views.py:2580
 msgid "No plan with that ID exists."
-msgstr ""
+msgstr "No map with that ID exists."
 
-#: redistricting/views.py:2637
+#: redistricting/views.py:2639
 #, python-format
 msgid "No functions for %(panel)s"
 msgstr ""
 
-#: redistricting/views.py:2646
+#: redistricting/views.py:2648
 #, python-format
 msgid "No user displays for %(user)s"
 msgstr ""
 
-#: redistricting/views.py:2668
+#: redistricting/views.py:2670
 msgid "Couldn't delete personalized scoredisplay"
 msgstr ""
 
-#: redistricting/views.py:2720
+#: redistricting/views.py:2722
 #, python-format
 msgid ""
 "Each user is limited to %(limit)d statistics sets. Please delete one or edit "
 "an existing set."
 msgstr ""
 
-#: redistricting/views.py:2738
+#: redistricting/views.py:2740
 msgid "Didn't get functions in POST parameter"
 msgstr ""
 
-#: redistricting/views.py:2774
+#: redistricting/views.py:2776
 msgid "No plan with that ID was found."
-msgstr ""
+msgstr "No map with that ID was found."

--- a/django/publicmapping/locale/es/LC_MESSAGES/django.po
+++ b/django/publicmapping/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-06 10:32-0400\n"
+"POT-Creation-Date: 2018-07-06 12:21-0400\n"
 "PO-Revision-Date: 2011-11-29 14:20\n"
 "Last-Translator: Admin User <ajennings+saigon@azavea.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -132,7 +132,7 @@ msgid "Sign Up"
 msgstr "Registrarse"
 
 #: publicmapping/templates/account.html:98
-#: redistricting/templates/editplan.html:400
+#: redistricting/templates/editplan.html:470
 msgid "Indicates required field"
 msgstr "Indica los campos requeridos"
 
@@ -1052,32 +1052,32 @@ msgstr ""
 "No hay unidades no asignadas podrían ser fijos. Asegúrese de que los "
 "distritos apropiados no están bloqueados."
 
-#: redistricting/models.py:3450
+#: redistricting/models.py:3538
 msgid "Unassigned"
 msgstr "Desasignar"
 
-#: redistricting/reportcalculators.py:53
-#: redistricting/reportcalculators.py:109
-#: redistricting/reportcalculators.py:141
+#: redistricting/reportcalculators.py:59
+#: redistricting/reportcalculators.py:117
+#: redistricting/reportcalculators.py:149
 msgid "DistrictID"
 msgstr "Identificación del distrito"
 
-#: redistricting/reportcalculators.py:57
-#: redistricting/reportcalculators.py:145
+#: redistricting/reportcalculators.py:63
+#: redistricting/reportcalculators.py:153
 #: redistricting/templates/basic_information.html:71
 msgid "Population"
 msgstr "Población"
 
-#: redistricting/reportcalculators.py:74
+#: redistricting/reportcalculators.py:80
 msgid "Within Target Range"
 msgstr "Dentro del rango permitido"
 
-#: redistricting/reportcalculators.py:113
+#: redistricting/reportcalculators.py:121
 #: redistricting/templates/viewplan.html:1043
 msgid "Compactness"
 msgstr "Compacidad"
 
-#: redistricting/reportcalculators.py:150
+#: redistricting/reportcalculators.py:158
 msgid "Proportion"
 msgstr "Proporción"
 
@@ -1136,7 +1136,7 @@ msgstr ""
 "Envío de la presentación de concurso de (usuario: %(username)s, planid: "
 "%(plan_id)d)"
 
-#: redistricting/tasks.py:685 redistricting/views.py:2157
+#: redistricting/tasks.py:685 redistricting/views.py:2159
 msgid "Plan submitted successfully"
 msgstr "El plan fue enviado satisfactoramente"
 
@@ -1457,7 +1457,7 @@ msgstr ""
 "este formulario."
 
 #: redistricting/templates/editplan.html:156
-#: redistricting/templates/editplan.html:396
+#: redistricting/templates/editplan.html:466
 msgid "Submit Final Plan"
 msgstr "Enviar el plan final"
 
@@ -1679,27 +1679,27 @@ msgstr "Número de teléfono"
 msgid "County"
 msgstr "Conteo"
 
-#: redistricting/templates/editplan.html:359
+#: redistricting/templates/editplan.html:429
 msgid "Zip code"
 msgstr ""
 
-#: redistricting/templates/editplan.html:363
+#: redistricting/templates/editplan.html:433
 msgid "Contest division"
 msgstr ""
 
-#: redistricting/templates/editplan.html:366
+#: redistricting/templates/editplan.html:436
 msgid "Youth (Grades 5-12)"
 msgstr ""
 
-#: redistricting/templates/editplan.html:367
+#: redistricting/templates/editplan.html:437
 msgid "Higher Ed (Undergraduate, Graduate, Professional)"
 msgstr ""
 
-#: redistricting/templates/editplan.html:368
+#: redistricting/templates/editplan.html:438
 msgid "Adult (Non-student)"
 msgstr ""
 
-#: redistricting/templates/editplan.html:374
+#: redistricting/templates/editplan.html:444
 msgid ""
 "Values &ndash; tell us what values, considerations and trade-offs you made "
 "in your plan:"
@@ -1707,7 +1707,7 @@ msgstr ""
 "Valores &ndash; díganos qué valores, consideraciones y restricciones utilizó "
 "en su plan:"
 
-#: redistricting/templates/editplan.html:384
+#: redistricting/templates/editplan.html:454
 msgid ""
 "\n"
 "                    By submitting a plan for consideration, you are "
@@ -1727,31 +1727,31 @@ msgstr ""
 "proyecto intentarán atribuirle  (a su nombre o al nombre del equipo) el plan "
 "cuando sea posible."
 
-#: redistricting/templates/editplan.html:418
+#: redistricting/templates/editplan.html:488
 msgid "Community Info"
 msgstr "Informacion de la comunidad"
 
-#: redistricting/templates/editplan.html:419
+#: redistricting/templates/editplan.html:489
 msgid "0"
 msgstr "0"
 
-#: redistricting/templates/editplan.html:423
+#: redistricting/templates/editplan.html:493
 msgid "1. Edit Community Label:"
 msgstr "1. Editar la etiqueta de la comunidad:"
 
-#: redistricting/templates/editplan.html:430
+#: redistricting/templates/editplan.html:500
 msgid "2. Edit Community Type:"
 msgstr "2. Editar el tipo de comunidad:"
 
-#: redistricting/templates/editplan.html:441
+#: redistricting/templates/editplan.html:511
 msgid "3. Comments:"
 msgstr "3. Comentarios:"
 
-#: redistricting/templates/editplan.html:449
+#: redistricting/templates/editplan.html:519
 msgid "Oops!"
 msgstr "¡Ups!"
 
-#: redistricting/templates/editplan.html:450
+#: redistricting/templates/editplan.html:520
 msgid "Sorry, your information could not be saved. Please try again later."
 msgstr ""
 "Lo sentimos, su información no se pudo guardar. Por favor inténtelo de nuevo "
@@ -2520,7 +2520,7 @@ msgid "You already have a plan named that. Please pick a unique name."
 msgstr ""
 "Usted ya tiene un plan con ese nombre. Por favor elija un nombre distinto"
 
-#: redistricting/views.py:336 redistricting/views.py:2130
+#: redistricting/views.py:336 redistricting/views.py:2131
 msgid "Could not save district copies"
 msgstr "No se pudieron guardar las copias de los distritos"
 
@@ -2544,312 +2544,312 @@ msgstr "plan"
 msgid "Couldn't save new plan"
 msgstr "No se pudo guardar el plan nuevo"
 
-#: redistricting/views.py:1018 redistricting/views.py:1219
-#: redistricting/views.py:1285 redistricting/views.py:1358
-#: redistricting/views.py:1421 redistricting/views.py:1469
+#: redistricting/views.py:1019 redistricting/views.py:1220
+#: redistricting/views.py:1286 redistricting/views.py:1359
+#: redistricting/views.py:1422 redistricting/views.py:1470
 msgid "No plan with the given id"
 msgstr "No existe un plan con la identificación proporcionada"
 
-#: redistricting/views.py:1023 redistricting/views.py:1474
-#: redistricting/views.py:1489
+#: redistricting/views.py:1024 redistricting/views.py:1475
+#: redistricting/views.py:1490
 msgid "User can't view the given plan"
 msgstr "El usuario no puede visualizar este plan"
 
-#: redistricting/views.py:1028
+#: redistricting/views.py:1029
 msgid "Information for report wasn't sent via POST"
 msgstr "La información para el informe no fue enviada vía POST"
 
-#: redistricting/views.py:1046
+#: redistricting/views.py:1047
 msgid "Plan report is ready."
 msgstr "El informe del plan está listo."
 
-#: redistricting/views.py:1054
+#: redistricting/views.py:1055
 msgid "Report is building."
 msgstr "El informe está en construcción"
 
-#: redistricting/views.py:1062
+#: redistricting/views.py:1063
 msgid "Report generation started."
 msgstr "El informe se empezó a generar."
 
-#: redistricting/views.py:1072
+#: redistricting/views.py:1073
 msgid "Unrecognized status when checking report status."
 msgstr "Estado desconocido al revisar el estado del informe."
 
-#: redistricting/views.py:1179
+#: redistricting/views.py:1180
 msgid "Created 1 new district"
 msgstr "Se creó 1 nuevo distrito"
 
-#: redistricting/views.py:1185
+#: redistricting/views.py:1186
 msgid "Reached Max districts already"
 msgstr "Número máximo de distritos alcanzado"
 
-#: redistricting/views.py:1189
+#: redistricting/views.py:1190
 msgid "Couldn't save new district."
 msgstr "No se pudo guardar el nuevo distrito."
 
-#: redistricting/views.py:1191
+#: redistricting/views.py:1192
 msgid "Must specify name, geolevel, and geounit ids for new district."
 msgstr ""
 "Debe espicificar las identificaciones del nombre, geonivel, y geounidad para "
 "el nuevo distrito."
 
-#: redistricting/views.py:1224 redistricting/views.py:1290
-#: redistricting/views.py:1363 redistricting/views.py:1426
+#: redistricting/views.py:1225 redistricting/views.py:1291
+#: redistricting/views.py:1364 redistricting/views.py:1427
 msgid "User can't edit the given plan"
 msgstr "El usuario no puede editar este plan"
 
-#: redistricting/views.py:1231
+#: redistricting/views.py:1232
 msgid "No districts selected to add to the given plan"
 msgstr "No se ha seleccionado ningún distrito para añadir a este plan"
 
-#: redistricting/views.py:1237
+#: redistricting/views.py:1238
 #, python-format
 msgid "Going to merge %(number_of_merged_districts)d districts"
 msgstr "Se fusionarán %(number_of_merged_districts)d distritos"
 
-#: redistricting/views.py:1245
+#: redistricting/views.py:1246
 #, python-format
 msgid "Tried to merge too many districts; %(allowed_districts)d slots left"
 msgstr ""
 "Se intentaron fusionar demasiado distritos; %(allowed_districts)d espacios "
 "vacios"
 
-#: redistricting/views.py:1252
+#: redistricting/views.py:1253
 #, python-format
 msgid "Merged %(num_merged_districts)d districts"
 msgstr "Se fusionaron %(num_merged_districts)d distritos"
 
-#: redistricting/views.py:1298
+#: redistricting/views.py:1299
 msgid "Multi-members not allowed for this legislative body"
 msgstr ""
 "Los distritos plurinomionales no son permitidos para este cuerpo legislativo"
 
-#: redistricting/views.py:1332
+#: redistricting/views.py:1333
 #, python-format
 msgid "Modified members for %(num_districts)d districts"
 msgstr "Se modificaron miembros %(num_districts)d para distritos"
 
-#: redistricting/views.py:1389
+#: redistricting/views.py:1390
 msgid "Can't combine locked districts"
 msgstr "No se puede combinar distritos bloqueados"
 
-#: redistricting/views.py:1398
+#: redistricting/views.py:1399
 msgid "Successfully combined districts"
 msgstr "Los distritos fueron combinados satisfactoramente"
 
-#: redistricting/views.py:1401
+#: redistricting/views.py:1402
 msgid "Could not combine districts"
 msgstr "No se pudieron combinar los distritos"
 
-#: redistricting/views.py:1437
+#: redistricting/views.py:1438
 msgid "Could not fix unassigned"
 msgstr "No se pudieron arreglar los no asignados"
 
-#: redistricting/views.py:1485
+#: redistricting/views.py:1486
 msgid "No other plan with the given id"
 msgstr "No existe otro plan con la identificación proporcionada"
 
-#: redistricting/views.py:1499
+#: redistricting/views.py:1500
 #, python-format
 msgid "othertype not supported: %(other)s"
 msgstr "othertype no compatible: %(other)s"
 
-#: redistricting/views.py:1505 redistricting/views.py:1506
+#: redistricting/views.py:1506 redistricting/views.py:1507
 msgid "split"
 msgstr "separar"
 
-#: redistricting/views.py:1509
+#: redistricting/views.py:1510
 #, python-format
 msgid "Found %(num_splits)d %(split_word)s"
 msgstr "Se encontraron %(num_splits)d %(split_word)s"
 
-#: redistricting/views.py:1515
+#: redistricting/views.py:1516
 msgid "Could not query for splits"
 msgstr "No se pudo realizar la consulta de las separaciones"
 
-#: redistricting/views.py:1529
+#: redistricting/views.py:1530
 msgid "No planIds provided"
 msgstr "No se proporcionó ningún planId"
 
-#: redistricting/views.py:1551
+#: redistricting/views.py:1552
 msgid "Plan does not exist."
 msgstr "El plan no existe."
 
-#: redistricting/views.py:1566
+#: redistricting/views.py:1567
 msgid "No layers were provided."
 msgstr "No se proporcionó ninguna capa."
 
-#: redistricting/views.py:1627 redistricting/views.py:1647
+#: redistricting/views.py:1628 redistricting/views.py:1648
 msgid "Could not add units to district."
 msgstr "No se pudo añadir unidades al distrito"
 
-#: redistricting/views.py:1639
+#: redistricting/views.py:1640
 #, python-format
 msgid "Updated %(num_fixed_districts)d districts"
 msgstr "Se actualizaron %(num_fixed_districts)d distritos"
 
-#: redistricting/views.py:1652
+#: redistricting/views.py:1653
 msgid "Geounits weren't found in a district."
 msgstr "No se encontraron geounidades en un distrito"
 
-#: redistricting/views.py:1682
+#: redistricting/views.py:1683
 msgid "Must include lock parameter."
 msgstr "Se tiene que incluir el parámetro de bloqueo."
 
-#: redistricting/views.py:1684
+#: redistricting/views.py:1685
 msgid "Must include version parameter."
 msgstr "Se tiene que incluir el parámetro de la versión."
 
-#: redistricting/views.py:1692
+#: redistricting/views.py:1693
 msgid "Plan or district does not exist."
 msgstr "El plan o el distrito no existen."
 
-#: redistricting/views.py:1702
+#: redistricting/views.py:1703
 #, python-format
 msgid "District successfully %(locked_state)s"
 msgstr "El distrito satisfactoriamente %(locked_state)s"
 
-#: redistricting/views.py:1703
+#: redistricting/views.py:1704
 msgid "locked"
 msgstr "bloqueado"
 
-#: redistricting/views.py:1703
+#: redistricting/views.py:1704
 msgid "unlocked"
 msgstr "desbloqueado"
 
-#: redistricting/views.py:1762
+#: redistricting/views.py:1763
 msgid "No plan exists with that ID."
 msgstr "No existe un plan con esa identificación"
 
-#: redistricting/views.py:1830
+#: redistricting/views.py:1831
 msgid "Subject for districts is required."
 msgstr "Se requiere un tema para los distritos"
 
-#: redistricting/views.py:1833
+#: redistricting/views.py:1834
 msgid "Query failed."
 msgstr "La consulta falló."
 
-#: redistricting/views.py:1940
+#: redistricting/views.py:1941
 msgid "Geometry is required."
 msgstr "Se requiere geometría."
 
-#: redistricting/views.py:1944
+#: redistricting/views.py:1945
 msgid "Invalid plan."
 msgstr "Plan inválido."
 
-#: redistricting/views.py:1958
+#: redistricting/views.py:1959
 msgid "Couldn't get geography info from the server. No plan with the given id."
 msgstr ""
 "No se pudo obtener la infomación geográfica desde el servidor. No existe un "
 "plan con la identificación proporcionada."
 
-#: redistricting/views.py:1976
+#: redistricting/views.py:1977
 msgid "Unable to get Demographics ScoreDisplay"
 msgstr "No se pudo obtener el ScoreDisplay personalizado"
 
-#: redistricting/views.py:1983
+#: redistricting/views.py:1984
 msgid "Unable to get Personalized ScoreDisplay"
 msgstr "No se pudo obtener el ScoreDisplay personalizado"
 
-#: redistricting/views.py:1994
+#: redistricting/views.py:1995
 msgid "Couldn't render display tab."
 msgstr "No se pudo pasar a la pestaña de visualización."
 
-#: redistricting/views.py:2028
+#: redistricting/views.py:2029
 msgid "Failed to get file status"
 msgstr "No se pudo obtener el estado del archivo"
 
-#: redistricting/views.py:2065
+#: redistricting/views.py:2066
 msgid "File is not yet ready. Please try again in a few minutes"
 msgstr ""
 "El archivo no está listo. Por favor vuelva a intentarlo en unos minutos"
 
-#: redistricting/views.py:2091
+#: redistricting/views.py:2092
 msgid "Task submitted"
 msgstr "Tarea presentada"
 
-#: redistricting/views.py:2115
+#: redistricting/views.py:2116
 msgid "Submission by: "
 msgstr ""
 
-#: redistricting/views.py:2200
+#: redistricting/views.py:2202
 msgid "No display configured"
 msgstr "No está configurada la visualización"
 
-#: redistricting/views.py:2306
+#: redistricting/views.py:2308
 msgid "Unknown filter method."
 msgstr "Método de Filtro desconocido."
 
-#: redistricting/views.py:2439
+#: redistricting/views.py:2441
 msgid "Must declare planId, name and description"
 msgstr "Se debe declarar el planId, el nombre y la descripción"
 
-#: redistricting/views.py:2452
+#: redistricting/views.py:2454
 msgid "Updated plan attributes"
 msgstr "Se actualizaron los atributos del plan"
 
-#: redistricting/views.py:2454
+#: redistricting/views.py:2456
 msgid "Failed to save the changes to your plan"
 msgstr "Se produjo un error al guardar los cambios hechos a su plan"
 
-#: redistricting/views.py:2459
+#: redistricting/views.py:2461
 msgid "Cannot edit a plan you don't own."
 msgstr "No puede editar un plan que no es suyo."
 
-#: redistricting/views.py:2476 redistricting/views.py:2509
+#: redistricting/views.py:2478 redistricting/views.py:2511
 msgid "Must declare planId"
 msgstr "Se debe establecer el planId"
 
-#: redistricting/views.py:2484
+#: redistricting/views.py:2486
 msgid "Deleted plan"
 msgstr "Se eliminó el plan"
 
-#: redistricting/views.py:2486
+#: redistricting/views.py:2488
 msgid "Failed to delete plan"
 msgstr "Se prdujo un error al eliminar el plan"
 
-#: redistricting/views.py:2491
+#: redistricting/views.py:2493
 msgid "Cannot delete a plan you don't own."
 msgstr "No puede eliminar un plan que no es suyo."
 
-#: redistricting/views.py:2523
+#: redistricting/views.py:2525
 msgid "Reaggregating plan"
 msgstr "Agregando nuevamente el plan"
 
-#: redistricting/views.py:2525
+#: redistricting/views.py:2527
 msgid "Failed to reaggregate plan"
 msgstr "Se produjo un error al agregar nuevamnete el plan"
 
-#: redistricting/views.py:2530
+#: redistricting/views.py:2532
 msgid "Cannot reaggregate a plan you don't own."
 msgstr "No puede agregar nuevamnete un plan que no es suyo."
 
-#: redistricting/views.py:2554
+#: redistricting/views.py:2556
 #, python-format
 msgid "Health retrieved at %(time)s\n"
 msgstr "Salud obtenida en %(time)s\n"
 
-#: redistricting/views.py:2555
+#: redistricting/views.py:2557
 #, python-format
 msgid "%(plan_count)d plans in database\n"
 msgstr "%(plan_count)d planes en la base de datos\n"
 
-#: redistricting/views.py:2557
+#: redistricting/views.py:2559
 #, python-format
 msgid "%(session_count)d sessions in use out of %(session_limit)s\n"
 msgstr "%(session_count)d sesiones en uso de %(session_limit)s\n"
 
-#: redistricting/views.py:2560
+#: redistricting/views.py:2562
 #, python-format
 msgid "%(num_users)d active users over the last 10 minutes\n"
 msgstr "%(num_users)d usuarios activos en los últimos 10 minutos\n"
 
-#: redistricting/views.py:2563
+#: redistricting/views.py:2565
 #, python-format
 msgid "%(mb_free)s MB of disk space free\n"
 msgstr "%(mb_free)s MB de espacio libre en disco\n"
 
-#: redistricting/views.py:2565
+#: redistricting/views.py:2567
 #, python-format
 msgid ""
 "Memory Usage:\n"
@@ -2858,7 +2858,7 @@ msgstr ""
 "Uso de memoria:\n"
 "%(mem_free)s\n"
 
-#: redistricting/views.py:2570
+#: redistricting/views.py:2572
 #, python-format
 msgid ""
 "ERROR! Couldn't get health:\n"
@@ -2867,25 +2867,25 @@ msgstr ""
 "ERROR! No se pudo obtener salud:\n"
 "%s"
 
-#: redistricting/views.py:2578
+#: redistricting/views.py:2580
 msgid "No plan with that ID exists."
 msgstr "No existe un plan con esa identificación."
 
-#: redistricting/views.py:2637
+#: redistricting/views.py:2639
 #, python-format
 msgid "No functions for %(panel)s"
 msgstr "No hay funciones para %(panel)s"
 
-#: redistricting/views.py:2646
+#: redistricting/views.py:2648
 #, python-format
 msgid "No user displays for %(user)s"
 msgstr "No hay visualizaciones disponibles para el usuario %(user)s"
 
-#: redistricting/views.py:2668
+#: redistricting/views.py:2670
 msgid "Couldn't delete personalized scoredisplay"
 msgstr "No se pudo eliminar el scoredisplay personalizado"
 
-#: redistricting/views.py:2720
+#: redistricting/views.py:2722
 #, python-format
 msgid ""
 "Each user is limited to %(limit)d statistics sets. Please delete one or edit "
@@ -2894,11 +2894,11 @@ msgstr ""
 "Cada usuario está limitado a %(limit)d conjuntos de estadísticas. Por favor "
 "elimine uno o edite un conjunto ya existente."
 
-#: redistricting/views.py:2738
+#: redistricting/views.py:2740
 msgid "Didn't get functions in POST parameter"
 msgstr "No se obtuvieron las funciones en el parámetro POST"
 
-#: redistricting/views.py:2774
+#: redistricting/views.py:2776
 msgid "No plan with that ID was found."
 msgstr "No se encontró un plan bajo esa identificación."
 

--- a/django/publicmapping/locale/fr/LC_MESSAGES/django.po
+++ b/django/publicmapping/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-06 10:32-0400\n"
+"POT-Creation-Date: 2018-07-06 12:21-0400\n"
 "PO-Revision-Date: 2011-11-29 14:20\n"
 "Last-Translator: Admin User <ajennings+saigon@azavea.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -132,7 +132,7 @@ msgid "Sign Up"
 msgstr "Inscrivez-vous"
 
 #: publicmapping/templates/account.html:98
-#: redistricting/templates/editplan.html:400
+#: redistricting/templates/editplan.html:470
 msgid "Indicates required field"
 msgstr "Indiquez le champ requis"
 
@@ -1055,32 +1055,32 @@ msgid ""
 "locked."
 msgstr ""
 
-#: redistricting/models.py:3450
+#: redistricting/models.py:3538
 msgid "Unassigned"
 msgstr "Désattribuer"
 
-#: redistricting/reportcalculators.py:53
-#: redistricting/reportcalculators.py:109
-#: redistricting/reportcalculators.py:141
+#: redistricting/reportcalculators.py:59
+#: redistricting/reportcalculators.py:117
+#: redistricting/reportcalculators.py:149
 msgid "DistrictID"
 msgstr "DistrictID"
 
-#: redistricting/reportcalculators.py:57
-#: redistricting/reportcalculators.py:145
+#: redistricting/reportcalculators.py:63
+#: redistricting/reportcalculators.py:153
 #: redistricting/templates/basic_information.html:71
 msgid "Population"
 msgstr "Population"
 
-#: redistricting/reportcalculators.py:74
+#: redistricting/reportcalculators.py:80
 msgid "Within Target Range"
 msgstr "Dans les limites de la cible"
 
-#: redistricting/reportcalculators.py:113
+#: redistricting/reportcalculators.py:121
 #: redistricting/templates/viewplan.html:1043
 msgid "Compactness"
 msgstr "Compacité"
 
-#: redistricting/reportcalculators.py:150
+#: redistricting/reportcalculators.py:158
 msgid "Proportion"
 msgstr "Proportion"
 
@@ -1136,7 +1136,7 @@ msgstr ""
 msgid "Competition submission (user: %(username)s, planid: %(plan_id)d)"
 msgstr "Soumission de la concurrence (user: %(username)s, planid: %(plan_id)d)"
 
-#: redistricting/tasks.py:685 redistricting/views.py:2157
+#: redistricting/tasks.py:685 redistricting/views.py:2159
 msgid "Plan submitted successfully"
 msgstr "Plan soumis avec succès"
 
@@ -1463,7 +1463,7 @@ msgstr ""
 "considérée pour le concours par remplir ce formulaire."
 
 #: redistricting/templates/editplan.html:156
-#: redistricting/templates/editplan.html:396
+#: redistricting/templates/editplan.html:466
 msgid "Submit Final Plan"
 msgstr "Soumettre la version finale du Plan"
 
@@ -1686,27 +1686,27 @@ msgstr "Numéro de téléphone"
 msgid "County"
 msgstr "Total"
 
-#: redistricting/templates/editplan.html:359
+#: redistricting/templates/editplan.html:429
 msgid "Zip code"
 msgstr ""
 
-#: redistricting/templates/editplan.html:363
+#: redistricting/templates/editplan.html:433
 msgid "Contest division"
 msgstr ""
 
-#: redistricting/templates/editplan.html:366
+#: redistricting/templates/editplan.html:436
 msgid "Youth (Grades 5-12)"
 msgstr ""
 
-#: redistricting/templates/editplan.html:367
+#: redistricting/templates/editplan.html:437
 msgid "Higher Ed (Undergraduate, Graduate, Professional)"
 msgstr ""
 
-#: redistricting/templates/editplan.html:368
+#: redistricting/templates/editplan.html:438
 msgid "Adult (Non-student)"
 msgstr ""
 
-#: redistricting/templates/editplan.html:374
+#: redistricting/templates/editplan.html:444
 msgid ""
 "Values &ndash; tell us what values, considerations and trade-offs you made "
 "in your plan:"
@@ -1714,7 +1714,7 @@ msgstr ""
 "Valeurs &ndash; dites-nous quelles valeurs, considérations et compromis vous "
 "avez fait sur votre plan:"
 
-#: redistricting/templates/editplan.html:384
+#: redistricting/templates/editplan.html:454
 msgid ""
 "\n"
 "                    By submitting a plan for consideration, you are "
@@ -1736,31 +1736,31 @@ msgstr ""
 " plan chaque fois que possible.\n"
 "                    "
 
-#: redistricting/templates/editplan.html:418
+#: redistricting/templates/editplan.html:488
 msgid "Community Info"
 msgstr "Infos de la communauté"
 
-#: redistricting/templates/editplan.html:419
+#: redistricting/templates/editplan.html:489
 msgid "0"
 msgstr "0"
 
-#: redistricting/templates/editplan.html:423
+#: redistricting/templates/editplan.html:493
 msgid "1. Edit Community Label:"
 msgstr "1. Modifier l'étiquette de la communauté:"
 
-#: redistricting/templates/editplan.html:430
+#: redistricting/templates/editplan.html:500
 msgid "2. Edit Community Type:"
 msgstr "2. Modifier le type de communauté:"
 
-#: redistricting/templates/editplan.html:441
+#: redistricting/templates/editplan.html:511
 msgid "3. Comments:"
 msgstr "3. Commentaires:"
 
-#: redistricting/templates/editplan.html:449
+#: redistricting/templates/editplan.html:519
 msgid "Oops!"
 msgstr "Oups!"
 
-#: redistricting/templates/editplan.html:450
+#: redistricting/templates/editplan.html:520
 msgid "Sorry, your information could not be saved. Please try again later."
 msgstr ""
 "Désolé, votre information n'a pu être sauvegardée. Veuillez réessayer plus "
@@ -2531,7 +2531,7 @@ msgstr "L'utilisateur %(username)s n'a pas l'autorisation de copier ce modèle"
 msgid "You already have a plan named that. Please pick a unique name."
 msgstr "Vous avez déjà un plan à ce nom. Veuillez choisir un nom unique."
 
-#: redistricting/views.py:336 redistricting/views.py:2130
+#: redistricting/views.py:336 redistricting/views.py:2131
 msgid "Could not save district copies"
 msgstr "Impossible d'enregistrer les copies de la circonscription"
 
@@ -2555,312 +2555,312 @@ msgstr "plan"
 msgid "Couldn't save new plan"
 msgstr "Impossible d'enregistrer le nouveau plan"
 
-#: redistricting/views.py:1018 redistricting/views.py:1219
-#: redistricting/views.py:1285 redistricting/views.py:1358
-#: redistricting/views.py:1421 redistricting/views.py:1469
+#: redistricting/views.py:1019 redistricting/views.py:1220
+#: redistricting/views.py:1286 redistricting/views.py:1359
+#: redistricting/views.py:1422 redistricting/views.py:1470
 msgid "No plan with the given id"
 msgstr "Il n'y a pas de plan avec l'identifiant donné"
 
-#: redistricting/views.py:1023 redistricting/views.py:1474
-#: redistricting/views.py:1489
+#: redistricting/views.py:1024 redistricting/views.py:1475
+#: redistricting/views.py:1490
 msgid "User can't view the given plan"
 msgstr "L'utilisateur ne peut pas afficher le plan donné"
 
-#: redistricting/views.py:1028
+#: redistricting/views.py:1029
 msgid "Information for report wasn't sent via POST"
 msgstr "L'information du rapport n'a pas été envoyée par le POST"
 
-#: redistricting/views.py:1046
+#: redistricting/views.py:1047
 msgid "Plan report is ready."
 msgstr "Le rapport du plan est prêt."
 
-#: redistricting/views.py:1054
+#: redistricting/views.py:1055
 msgid "Report is building."
 msgstr "Le rapport est en construction."
 
-#: redistricting/views.py:1062
+#: redistricting/views.py:1063
 msgid "Report generation started."
 msgstr "La génération du rapport a commencé."
 
-#: redistricting/views.py:1072
+#: redistricting/views.py:1073
 msgid "Unrecognized status when checking report status."
 msgstr "Statut non reconnu lors de la vérification de l'état du rapport."
 
-#: redistricting/views.py:1179
+#: redistricting/views.py:1180
 msgid "Created 1 new district"
 msgstr "Vous avez créé 1 nouvelle circonscription"
 
-#: redistricting/views.py:1185
+#: redistricting/views.py:1186
 msgid "Reached Max districts already"
 msgstr "Vous avez déjà atteint le nombre maximum de circonscriptions"
 
-#: redistricting/views.py:1189
+#: redistricting/views.py:1190
 msgid "Couldn't save new district."
 msgstr "Impossible d'enregistrer la nouvelle circonscription."
 
-#: redistricting/views.py:1191
+#: redistricting/views.py:1192
 msgid "Must specify name, geolevel, and geounit ids for new district."
 msgstr ""
 "Vous devez spécifier les identifiants du nom, du geolevel, et du géounit de "
 "la nouvelle circonscription."
 
-#: redistricting/views.py:1224 redistricting/views.py:1290
-#: redistricting/views.py:1363 redistricting/views.py:1426
+#: redistricting/views.py:1225 redistricting/views.py:1291
+#: redistricting/views.py:1364 redistricting/views.py:1427
 msgid "User can't edit the given plan"
 msgstr "L'utilisateur ne peut pas modifier le plan donné"
 
-#: redistricting/views.py:1231
+#: redistricting/views.py:1232
 msgid "No districts selected to add to the given plan"
 msgstr "Aucune circonscription sélectionnée pour ajouter au plan donné"
 
-#: redistricting/views.py:1237
+#: redistricting/views.py:1238
 #, python-format
 msgid "Going to merge %(number_of_merged_districts)d districts"
 msgstr "Va fusionner %(number_of_merged_districts)d circonscriptions"
 
-#: redistricting/views.py:1245
+#: redistricting/views.py:1246
 #, python-format
 msgid "Tried to merge too many districts; %(allowed_districts)d slots left"
 msgstr ""
 "Vous avez essayé de fusionner trop de circonscriptions; "
 "%(allowed_districts)d emplacements restants"
 
-#: redistricting/views.py:1252
+#: redistricting/views.py:1253
 #, python-format
 msgid "Merged %(num_merged_districts)d districts"
 msgstr "Fusion %(num_merged_districts)d circonscriptions"
 
-#: redistricting/views.py:1298
+#: redistricting/views.py:1299
 msgid "Multi-members not allowed for this legislative body"
 msgstr "Multi-membres non autorisés pour ce corps législatif"
 
-#: redistricting/views.py:1332
+#: redistricting/views.py:1333
 #, python-format
 msgid "Modified members for %(num_districts)d districts"
 msgstr "Modification de membres pour %(num_districts)d de circonscriptions"
 
-#: redistricting/views.py:1389
+#: redistricting/views.py:1390
 msgid "Can't combine locked districts"
 msgstr "Vouz ne pouvez pas combiner les circonscriptions verrouillées"
 
-#: redistricting/views.py:1398
+#: redistricting/views.py:1399
 msgid "Successfully combined districts"
 msgstr "Circonscriptions combinées avec success"
 
-#: redistricting/views.py:1401
+#: redistricting/views.py:1402
 msgid "Could not combine districts"
 msgstr "Impossible de combiner les circonscriptions"
 
-#: redistricting/views.py:1437
+#: redistricting/views.py:1438
 msgid "Could not fix unassigned"
 msgstr "Impossible de fixer les non assignées"
 
-#: redistricting/views.py:1485
+#: redistricting/views.py:1486
 msgid "No other plan with the given id"
 msgstr "Aucun autre plan avec l'identifiant donné"
 
-#: redistricting/views.py:1499
+#: redistricting/views.py:1500
 #, python-format
 msgid "othertype not supported: %(other)s"
 msgstr "autre type non pris en charge: %(other)s"
 
-#: redistricting/views.py:1505 redistricting/views.py:1506
+#: redistricting/views.py:1506 redistricting/views.py:1507
 msgid "split"
 msgstr "division"
 
-#: redistricting/views.py:1509
+#: redistricting/views.py:1510
 #, python-format
 msgid "Found %(num_splits)d %(split_word)s"
 msgstr "Trouvé %(num_splits)d %(split_word)s"
 
-#: redistricting/views.py:1515
+#: redistricting/views.py:1516
 msgid "Could not query for splits"
 msgstr "Impossible d'effectuer une requête de divisions"
 
-#: redistricting/views.py:1529
+#: redistricting/views.py:1530
 msgid "No planIds provided"
 msgstr "Aucun identifiant de plan fourni"
 
-#: redistricting/views.py:1551
+#: redistricting/views.py:1552
 msgid "Plan does not exist."
 msgstr "Le plan n'existe pas"
 
-#: redistricting/views.py:1566
+#: redistricting/views.py:1567
 msgid "No layers were provided."
 msgstr "Aucune couche n'a été fournie."
 
-#: redistricting/views.py:1627 redistricting/views.py:1647
+#: redistricting/views.py:1628 redistricting/views.py:1648
 msgid "Could not add units to district."
 msgstr "Impossible d'ajouter des unités à la circonscription."
 
-#: redistricting/views.py:1639
+#: redistricting/views.py:1640
 #, python-format
 msgid "Updated %(num_fixed_districts)d districts"
 msgstr "Circonscriptions %(num_fixed_districts)d réactualisées"
 
-#: redistricting/views.py:1652
+#: redistricting/views.py:1653
 msgid "Geounits weren't found in a district."
 msgstr "Les géounits n'ont pas été trouvées dans une circonscription."
 
-#: redistricting/views.py:1682
+#: redistricting/views.py:1683
 msgid "Must include lock parameter."
 msgstr "Doit inclure un paramètre de verrouillage."
 
-#: redistricting/views.py:1684
+#: redistricting/views.py:1685
 msgid "Must include version parameter."
 msgstr "Doit inclure un paramètre de version."
 
-#: redistricting/views.py:1692
+#: redistricting/views.py:1693
 msgid "Plan or district does not exist."
 msgstr "Le plan ou la circonscription n'existe pas."
 
-#: redistricting/views.py:1702
+#: redistricting/views.py:1703
 #, python-format
 msgid "District successfully %(locked_state)s"
 msgstr "Circonscription %(locked_state)s avec succès"
 
-#: redistricting/views.py:1703
+#: redistricting/views.py:1704
 msgid "locked"
 msgstr "verrouillé"
 
-#: redistricting/views.py:1703
+#: redistricting/views.py:1704
 msgid "unlocked"
 msgstr "déverrouillé"
 
-#: redistricting/views.py:1762
+#: redistricting/views.py:1763
 msgid "No plan exists with that ID."
 msgstr "Il n'existe pas de plan avec cet identifiant."
 
-#: redistricting/views.py:1830
+#: redistricting/views.py:1831
 msgid "Subject for districts is required."
 msgstr "L'objet des circonscriptions est requis"
 
-#: redistricting/views.py:1833
+#: redistricting/views.py:1834
 msgid "Query failed."
 msgstr "Echec de la requête."
 
-#: redistricting/views.py:1940
+#: redistricting/views.py:1941
 msgid "Geometry is required."
 msgstr "La géométrie est nécessaire."
 
-#: redistricting/views.py:1944
+#: redistricting/views.py:1945
 msgid "Invalid plan."
 msgstr "Plan non valide."
 
-#: redistricting/views.py:1958
+#: redistricting/views.py:1959
 msgid "Couldn't get geography info from the server. No plan with the given id."
 msgstr ""
 "Impossible d'obtenir des informations géographiques du serveur. Pas de plan "
 "avec l'identifiant donné."
 
-#: redistricting/views.py:1976
+#: redistricting/views.py:1977
 msgid "Unable to get Demographics ScoreDisplay"
 msgstr "Impossible d'obtenir un affichage de score démographiques"
 
-#: redistricting/views.py:1983
+#: redistricting/views.py:1984
 msgid "Unable to get Personalized ScoreDisplay"
 msgstr "Impossible d'obtenir un affichage de score personnalisés"
 
-#: redistricting/views.py:1994
+#: redistricting/views.py:1995
 msgid "Couldn't render display tab."
 msgstr "Impossible d'afficher l'onglet d'affichage."
 
-#: redistricting/views.py:2028
+#: redistricting/views.py:2029
 msgid "Failed to get file status"
 msgstr "Impossible d'obtenir le statut du fichier"
 
-#: redistricting/views.py:2065
+#: redistricting/views.py:2066
 msgid "File is not yet ready. Please try again in a few minutes"
 msgstr ""
 "Le fichier n'est pas encore prêt. Veuillez essayer à nouveau dans quelques "
 "minutes"
 
-#: redistricting/views.py:2091
+#: redistricting/views.py:2092
 msgid "Task submitted"
 msgstr "Tâche soumise"
 
-#: redistricting/views.py:2115
+#: redistricting/views.py:2116
 msgid "Submission by: "
 msgstr ""
 
-#: redistricting/views.py:2200
+#: redistricting/views.py:2202
 msgid "No display configured"
 msgstr "Aucun affichage configuré"
 
-#: redistricting/views.py:2306
+#: redistricting/views.py:2308
 msgid "Unknown filter method."
 msgstr "Méthode de filtrage inconnue."
 
-#: redistricting/views.py:2439
+#: redistricting/views.py:2441
 msgid "Must declare planId, name and description"
 msgstr "Doit déclarer l'identifiant du plan, nom et description"
 
-#: redistricting/views.py:2452
+#: redistricting/views.py:2454
 msgid "Updated plan attributes"
 msgstr "Attributs du plan réactualisés"
 
-#: redistricting/views.py:2454
+#: redistricting/views.py:2456
 msgid "Failed to save the changes to your plan"
 msgstr "Impossible d'enregistrer les modifications apportées à votre plan"
 
-#: redistricting/views.py:2459
+#: redistricting/views.py:2461
 msgid "Cannot edit a plan you don't own."
 msgstr "Impossible de modifier un plan que vous ne possédez pas."
 
-#: redistricting/views.py:2476 redistricting/views.py:2509
+#: redistricting/views.py:2478 redistricting/views.py:2511
 msgid "Must declare planId"
 msgstr "Doit déclarer l'identifiant du plan"
 
-#: redistricting/views.py:2484
+#: redistricting/views.py:2486
 msgid "Deleted plan"
 msgstr "Plan supprimé"
 
-#: redistricting/views.py:2486
+#: redistricting/views.py:2488
 msgid "Failed to delete plan"
 msgstr "Impossible de supprimer le plan"
 
-#: redistricting/views.py:2491
+#: redistricting/views.py:2493
 msgid "Cannot delete a plan you don't own."
 msgstr "Impossible de supprimer un plan que vous ne possédez pas."
 
-#: redistricting/views.py:2523
+#: redistricting/views.py:2525
 msgid "Reaggregating plan"
 msgstr "Réagrégation du plan"
 
-#: redistricting/views.py:2525
+#: redistricting/views.py:2527
 msgid "Failed to reaggregate plan"
 msgstr "Échec de réagrégation du plan"
 
-#: redistricting/views.py:2530
+#: redistricting/views.py:2532
 msgid "Cannot reaggregate a plan you don't own."
 msgstr "Impossible de réagréger un plan que vous ne possédez pas."
 
-#: redistricting/views.py:2554
+#: redistricting/views.py:2556
 #, python-format
 msgid "Health retrieved at %(time)s\n"
 msgstr "état du programme récupéré à %(time)s\n"
 
-#: redistricting/views.py:2555
+#: redistricting/views.py:2557
 #, python-format
 msgid "%(plan_count)d plans in database\n"
 msgstr "%(plan_count)d plans dans la base de données\n"
 
-#: redistricting/views.py:2557
+#: redistricting/views.py:2559
 #, python-format
 msgid "%(session_count)d sessions in use out of %(session_limit)s\n"
 msgstr "%(session_count)d sessions utilisées sur %(session_limit)s\n"
 
-#: redistricting/views.py:2560
+#: redistricting/views.py:2562
 #, python-format
 msgid "%(num_users)d active users over the last 10 minutes\n"
 msgstr "%(num_users) d’utilisateurs actifs au cours des 10 dernières minutes\n"
 
-#: redistricting/views.py:2563
+#: redistricting/views.py:2565
 #, python-format
 msgid "%(mb_free)s MB of disk space free\n"
 msgstr "%(mb_free)s MO d'espace de disque disponible\n"
 
-#: redistricting/views.py:2565
+#: redistricting/views.py:2567
 #, python-format
 msgid ""
 "Memory Usage:\n"
@@ -2869,7 +2869,7 @@ msgstr ""
 "Utilisation de mémoire:\n"
 "%(mem_free)s\n"
 
-#: redistricting/views.py:2570
+#: redistricting/views.py:2572
 #, python-format
 msgid ""
 "ERROR! Couldn't get health:\n"
@@ -2878,25 +2878,25 @@ msgstr ""
 "ERREUR! Impossible d'obtenir l'état du programme:\n"
 "%s"
 
-#: redistricting/views.py:2578
+#: redistricting/views.py:2580
 msgid "No plan with that ID exists."
 msgstr "Il n'existe aucun plan avec cet identifiant."
 
-#: redistricting/views.py:2637
+#: redistricting/views.py:2639
 #, python-format
 msgid "No functions for %(panel)s"
 msgstr "Aucune fonction pour %(panel)s"
 
-#: redistricting/views.py:2646
+#: redistricting/views.py:2648
 #, python-format
 msgid "No user displays for %(user)s"
 msgstr "Aucun utilisateur ne s'affiche pour %(user)s"
 
-#: redistricting/views.py:2668
+#: redistricting/views.py:2670
 msgid "Couldn't delete personalized scoredisplay"
 msgstr "Impossible de supprimer un affichage de score personnalisé"
 
-#: redistricting/views.py:2720
+#: redistricting/views.py:2722
 #, python-format
 msgid ""
 "Each user is limited to %(limit)d statistics sets. Please delete one or edit "
@@ -2905,11 +2905,11 @@ msgstr ""
 "Chaque utilisateur est limité à %(limit)d d'ensembles statistiques. Veuillez "
 "supprimer un ou modifier un ensemble existant."
 
-#: redistricting/views.py:2738
+#: redistricting/views.py:2740
 msgid "Didn't get functions in POST parameter"
 msgstr "N'a pas obtenu les fonctions dans le paramètre POST"
 
-#: redistricting/views.py:2774
+#: redistricting/views.py:2776
 msgid "No plan with that ID was found."
 msgstr "Impossible de trouver un plan avec cet identifiant."
 

--- a/django/publicmapping/locale/ja/LC_MESSAGES/django.po
+++ b/django/publicmapping/locale/ja/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-06 10:32-0400\n"
+"POT-Creation-Date: 2018-07-06 12:21-0400\n"
 "PO-Revision-Date: 2012-06-07 14:20\n"
 "Language: Japanese\n"
 "MIME-Version: 1.0\n"
@@ -126,7 +126,7 @@ msgid "Sign Up"
 msgstr "登録"
 
 #: publicmapping/templates/account.html:98
-#: redistricting/templates/editplan.html:400
+#: redistricting/templates/editplan.html:470
 msgid "Indicates required field"
 msgstr "必須項目"
 
@@ -1011,32 +1011,32 @@ msgid ""
 "locked."
 msgstr ""
 
-#: redistricting/models.py:3450
+#: redistricting/models.py:3538
 msgid "Unassigned"
 msgstr "割り当て解除"
 
-#: redistricting/reportcalculators.py:53
-#: redistricting/reportcalculators.py:109
-#: redistricting/reportcalculators.py:141
+#: redistricting/reportcalculators.py:59
+#: redistricting/reportcalculators.py:117
+#: redistricting/reportcalculators.py:149
 msgid "DistrictID"
 msgstr "選挙区ID"
 
-#: redistricting/reportcalculators.py:57
-#: redistricting/reportcalculators.py:145
+#: redistricting/reportcalculators.py:63
+#: redistricting/reportcalculators.py:153
 #: redistricting/templates/basic_information.html:71
 msgid "Population"
 msgstr "人口"
 
-#: redistricting/reportcalculators.py:74
+#: redistricting/reportcalculators.py:80
 msgid "Within Target Range"
 msgstr "目標人口範囲内"
 
-#: redistricting/reportcalculators.py:113
+#: redistricting/reportcalculators.py:121
 #: redistricting/templates/viewplan.html:1043
 msgid "Compactness"
 msgstr "Compacidad"
 
-#: redistricting/reportcalculators.py:150
+#: redistricting/reportcalculators.py:158
 msgid "Proportion"
 msgstr "割合"
 
@@ -1090,7 +1090,7 @@ msgstr ""
 msgid "Competition submission (user: %(username)s, planid: %(plan_id)d)"
 msgstr "コンテストへの提出 (ﾕｰｻﾞ: %(username)s, 計画案ID: %(plan_id)d)"
 
-#: redistricting/tasks.py:685 redistricting/views.py:2157
+#: redistricting/tasks.py:685 redistricting/views.py:2159
 msgid "Plan submitted successfully"
 msgstr "計画案を提出しました"
 
@@ -1407,7 +1407,7 @@ msgstr ""
 "完成した計画案をコンテストに提出するにはこのフォームを記入してください。"
 
 #: redistricting/templates/editplan.html:156
-#: redistricting/templates/editplan.html:396
+#: redistricting/templates/editplan.html:466
 msgid "Submit Final Plan"
 msgstr "最終計画案を提出"
 
@@ -1617,27 +1617,27 @@ msgstr "電話番号"
 msgid "County"
 msgstr "数"
 
-#: redistricting/templates/editplan.html:359
+#: redistricting/templates/editplan.html:429
 msgid "Zip code"
 msgstr ""
 
-#: redistricting/templates/editplan.html:363
+#: redistricting/templates/editplan.html:433
 msgid "Contest division"
 msgstr ""
 
-#: redistricting/templates/editplan.html:366
+#: redistricting/templates/editplan.html:436
 msgid "Youth (Grades 5-12)"
 msgstr ""
 
-#: redistricting/templates/editplan.html:367
+#: redistricting/templates/editplan.html:437
 msgid "Higher Ed (Undergraduate, Graduate, Professional)"
 msgstr ""
 
-#: redistricting/templates/editplan.html:368
+#: redistricting/templates/editplan.html:438
 msgid "Adult (Non-student)"
 msgstr ""
 
-#: redistricting/templates/editplan.html:374
+#: redistricting/templates/editplan.html:444
 msgid ""
 "Values &ndash; tell us what values, considerations and trade-offs you made "
 "in your plan:"
@@ -1645,7 +1645,7 @@ msgstr ""
 "価値観 &ndash; この計画案の作成にどのような価値観、考慮、また取引が反映されて"
 "いますか。:"
 
-#: redistricting/templates/editplan.html:384
+#: redistricting/templates/editplan.html:454
 #, fuzzy
 msgid ""
 "\n"
@@ -1666,31 +1666,31 @@ msgstr ""
 "トのパートナーは\n"
 "                    あなたの名前やチーム名などの計画案の情報を公開します。\n"
 
-#: redistricting/templates/editplan.html:418
+#: redistricting/templates/editplan.html:488
 msgid "Community Info"
 msgstr "地域情報"
 
-#: redistricting/templates/editplan.html:419
+#: redistricting/templates/editplan.html:489
 msgid "0"
 msgstr "0"
 
-#: redistricting/templates/editplan.html:423
+#: redistricting/templates/editplan.html:493
 msgid "1. Edit Community Label:"
 msgstr "1. 地域名を編集:"
 
-#: redistricting/templates/editplan.html:430
+#: redistricting/templates/editplan.html:500
 msgid "2. Edit Community Type:"
 msgstr "2. 地域ﾀｲﾌﾟを編集:"
 
-#: redistricting/templates/editplan.html:441
+#: redistricting/templates/editplan.html:511
 msgid "3. Comments:"
 msgstr "3. コメント:"
 
-#: redistricting/templates/editplan.html:449
+#: redistricting/templates/editplan.html:519
 msgid "Oops!"
 msgstr "おぉっと！"
 
-#: redistricting/templates/editplan.html:450
+#: redistricting/templates/editplan.html:520
 msgid "Sorry, your information could not be saved. Please try again later."
 msgstr ""
 "残念ながら、あなたの情報は保存されませんでした。しばらく経ってからやり直して"
@@ -2429,7 +2429,7 @@ msgstr "ユーザ%(username)sはこのモデルをコピーすることはでき
 msgid "You already have a plan named that. Please pick a unique name."
 msgstr "同じ名前の計画案が既にあります。別の名前をつけてください。"
 
-#: redistricting/views.py:336 redistricting/views.py:2130
+#: redistricting/views.py:336 redistricting/views.py:2131
 msgid "Could not save district copies"
 msgstr "選挙区のコピーを保存できませんでした。"
 
@@ -2453,310 +2453,310 @@ msgstr "計画案"
 msgid "Couldn't save new plan"
 msgstr "新しい計画案を保存できませんでした"
 
-#: redistricting/views.py:1018 redistricting/views.py:1219
-#: redistricting/views.py:1285 redistricting/views.py:1358
-#: redistricting/views.py:1421 redistricting/views.py:1469
+#: redistricting/views.py:1019 redistricting/views.py:1220
+#: redistricting/views.py:1286 redistricting/views.py:1359
+#: redistricting/views.py:1422 redistricting/views.py:1470
 msgid "No plan with the given id"
 msgstr "指定されたIDの計画案は存在しません"
 
-#: redistricting/views.py:1023 redistricting/views.py:1474
-#: redistricting/views.py:1489
+#: redistricting/views.py:1024 redistricting/views.py:1475
+#: redistricting/views.py:1490
 msgid "User can't view the given plan"
 msgstr "指定された計画案を見ることはできません"
 
-#: redistricting/views.py:1028
+#: redistricting/views.py:1029
 msgid "Information for report wasn't sent via POST"
 msgstr "レポート情報がPOSTから送られませんでした"
 
-#: redistricting/views.py:1046
+#: redistricting/views.py:1047
 msgid "Plan report is ready."
 msgstr "計画案レポートの準備ができました。"
 
-#: redistricting/views.py:1054
+#: redistricting/views.py:1055
 msgid "Report is building."
 msgstr "レポートを構築中です。"
 
-#: redistricting/views.py:1062
+#: redistricting/views.py:1063
 msgid "Report generation started."
 msgstr "レポート作成を開始しました"
 
-#: redistricting/views.py:1072
+#: redistricting/views.py:1073
 msgid "Unrecognized status when checking report status."
 msgstr ""
 
-#: redistricting/views.py:1179
+#: redistricting/views.py:1180
 msgid "Created 1 new district"
 msgstr "新しい選挙区を作成しました"
 
-#: redistricting/views.py:1185
+#: redistricting/views.py:1186
 msgid "Reached Max districts already"
 msgstr "選挙区数の上限に達しています"
 
-#: redistricting/views.py:1189
+#: redistricting/views.py:1190
 msgid "Couldn't save new district."
 msgstr "新しい選挙区を保存できませんでした。"
 
-#: redistricting/views.py:1191
+#: redistricting/views.py:1192
 msgid "Must specify name, geolevel, and geounit ids for new district."
 msgstr "新しい選挙区の名前、地域レベル、地域単位を指定してください。"
 
-#: redistricting/views.py:1224 redistricting/views.py:1290
-#: redistricting/views.py:1363 redistricting/views.py:1426
+#: redistricting/views.py:1225 redistricting/views.py:1291
+#: redistricting/views.py:1364 redistricting/views.py:1427
 msgid "User can't edit the given plan"
 msgstr "この計画案は編集することができません"
 
-#: redistricting/views.py:1231
+#: redistricting/views.py:1232
 msgid "No districts selected to add to the given plan"
 msgstr "新しい計画案に追加する選挙区が選択されていません"
 
-#: redistricting/views.py:1237
+#: redistricting/views.py:1238
 #, python-format
 msgid "Going to merge %(number_of_merged_districts)d districts"
 msgstr "%(number_of_merged_districts)d個の選挙区を統合します"
 
-#: redistricting/views.py:1245
+#: redistricting/views.py:1246
 #, python-format
 msgid "Tried to merge too many districts; %(allowed_districts)d slots left"
 msgstr ""
 "統合しようとした選挙区が多すぎます。%(allowed_districts)d個分のスロットが残っ"
 "ています。"
 
-#: redistricting/views.py:1252
+#: redistricting/views.py:1253
 #, python-format
 msgid "Merged %(num_merged_districts)d districts"
 msgstr "%(num_merged_districts)d個の選挙区を統合しました"
 
-#: redistricting/views.py:1298
+#: redistricting/views.py:1299
 msgid "Multi-members not allowed for this legislative body"
 msgstr "この議会は複数定員区にすることはできません"
 
-#: redistricting/views.py:1332
+#: redistricting/views.py:1333
 #, python-format
 msgid "Modified members for %(num_districts)d districts"
 msgstr "%(num_districts)d個の選挙区の議員を変更しました"
 
-#: redistricting/views.py:1389
+#: redistricting/views.py:1390
 msgid "Can't combine locked districts"
 msgstr "ロックされた選挙区を統合することはできません"
 
-#: redistricting/views.py:1398
+#: redistricting/views.py:1399
 msgid "Successfully combined districts"
 msgstr "選挙区の統合に成功しました"
 
-#: redistricting/views.py:1401
+#: redistricting/views.py:1402
 msgid "Could not combine districts"
 msgstr "選挙区を統合できませんでした"
 
-#: redistricting/views.py:1437
+#: redistricting/views.py:1438
 msgid "Could not fix unassigned"
 msgstr "未配置地域の修復ができませんでした"
 
-#: redistricting/views.py:1485
+#: redistricting/views.py:1486
 msgid "No other plan with the given id"
 msgstr "指定されたIDの計画案は他にありません。"
 
-#: redistricting/views.py:1499
+#: redistricting/views.py:1500
 #, python-format
 msgid "othertype not supported: %(other)s"
 msgstr "othertypeはサポートされていません: %(other)s"
 
-#: redistricting/views.py:1505 redistricting/views.py:1506
+#: redistricting/views.py:1506 redistricting/views.py:1507
 msgid "split"
 msgstr "分割"
 
-#: redistricting/views.py:1509
+#: redistricting/views.py:1510
 #, python-format
 msgid "Found %(num_splits)d %(split_word)s"
 msgstr "%(num_splits)d個の%(split_word)sが見つかりました"
 
-#: redistricting/views.py:1515
+#: redistricting/views.py:1516
 msgid "Could not query for splits"
 msgstr "分割の問い合わせができませんでした"
 
-#: redistricting/views.py:1529
+#: redistricting/views.py:1530
 msgid "No planIds provided"
 msgstr "計画案IDが指定されていません"
 
-#: redistricting/views.py:1551
+#: redistricting/views.py:1552
 msgid "Plan does not exist."
 msgstr "計画案が存在しません。"
 
-#: redistricting/views.py:1566
+#: redistricting/views.py:1567
 msgid "No layers were provided."
 msgstr "layerが指定されていません。"
 
-#: redistricting/views.py:1627 redistricting/views.py:1647
+#: redistricting/views.py:1628 redistricting/views.py:1648
 msgid "Could not add units to district."
 msgstr "地域単位を選挙区に追加できませんでした。"
 
-#: redistricting/views.py:1639
+#: redistricting/views.py:1640
 #, python-format
 msgid "Updated %(num_fixed_districts)d districts"
 msgstr "%(num_fixed_districts)d個の選挙区を更新しました"
 
-#: redistricting/views.py:1652
+#: redistricting/views.py:1653
 msgid "Geounits weren't found in a district."
 msgstr "選挙区内に地域単位が見つかりませんでした。"
 
-#: redistricting/views.py:1682
+#: redistricting/views.py:1683
 msgid "Must include lock parameter."
 msgstr "lock parameterを組み込んでください。"
 
-#: redistricting/views.py:1684
+#: redistricting/views.py:1685
 msgid "Must include version parameter."
 msgstr "version parameterを組み込んでください。"
 
-#: redistricting/views.py:1692
+#: redistricting/views.py:1693
 msgid "Plan or district does not exist."
 msgstr "計画案か選挙区が存在しません。"
 
-#: redistricting/views.py:1702
+#: redistricting/views.py:1703
 #, python-format
 msgid "District successfully %(locked_state)s"
 msgstr ""
 
-#: redistricting/views.py:1703
+#: redistricting/views.py:1704
 msgid "locked"
 msgstr "ロックされました"
 
-#: redistricting/views.py:1703
+#: redistricting/views.py:1704
 msgid "unlocked"
 msgstr "ロックを解除しました"
 
-#: redistricting/views.py:1762
+#: redistricting/views.py:1763
 msgid "No plan exists with that ID."
 msgstr "そのIDの計画案は存在しません。"
 
-#: redistricting/views.py:1830
+#: redistricting/views.py:1831
 msgid "Subject for districts is required."
 msgstr "選挙区のSubjectが必要です。"
 
-#: redistricting/views.py:1833
+#: redistricting/views.py:1834
 msgid "Query failed."
 msgstr "クエリーに失敗しました。"
 
-#: redistricting/views.py:1940
+#: redistricting/views.py:1941
 msgid "Geometry is required."
 msgstr "Geometryが必要です。"
 
-#: redistricting/views.py:1944
+#: redistricting/views.py:1945
 msgid "Invalid plan."
 msgstr "無効な計画案です。"
 
-#: redistricting/views.py:1958
+#: redistricting/views.py:1959
 msgid "Couldn't get geography info from the server. No plan with the given id."
 msgstr ""
 "サーバーから地域情報が取得できませんでした。指定されたIDの計画案はありませ"
 "ん。"
 
-#: redistricting/views.py:1976
+#: redistricting/views.py:1977
 #, fuzzy
 msgid "Unable to get Demographics ScoreDisplay"
 msgstr "Personalized ScoreDisplayを取得できません。"
 
-#: redistricting/views.py:1983
+#: redistricting/views.py:1984
 msgid "Unable to get Personalized ScoreDisplay"
 msgstr "Personalized ScoreDisplayを取得できません。"
 
-#: redistricting/views.py:1994
+#: redistricting/views.py:1995
 msgid "Couldn't render display tab."
 msgstr "display tabが作成できませんでした。"
 
-#: redistricting/views.py:2028
+#: redistricting/views.py:2029
 msgid "Failed to get file status"
 msgstr "ファイルステータスを取得できませんでした"
 
-#: redistricting/views.py:2065
+#: redistricting/views.py:2066
 msgid "File is not yet ready. Please try again in a few minutes"
 msgstr "ファイルが準備できていません。しばらくしてやり直してください。"
 
-#: redistricting/views.py:2091
+#: redistricting/views.py:2092
 msgid "Task submitted"
 msgstr "タスクを提出しました。"
 
-#: redistricting/views.py:2115
+#: redistricting/views.py:2116
 msgid "Submission by: "
 msgstr ""
 
-#: redistricting/views.py:2200
+#: redistricting/views.py:2202
 msgid "No display configured"
 msgstr "ディスプレイが設定されていません"
 
-#: redistricting/views.py:2306
+#: redistricting/views.py:2308
 msgid "Unknown filter method."
 msgstr "検索条件が不明です。"
 
-#: redistricting/views.py:2439
+#: redistricting/views.py:2441
 msgid "Must declare planId, name and description"
 msgstr "計画案IDと名前、説明の記入が必要です"
 
-#: redistricting/views.py:2452
+#: redistricting/views.py:2454
 msgid "Updated plan attributes"
 msgstr "計画案の属性を更新しました"
 
-#: redistricting/views.py:2454
+#: redistricting/views.py:2456
 msgid "Failed to save the changes to your plan"
 msgstr "計画案への変更を保存できませんでした"
 
-#: redistricting/views.py:2459
+#: redistricting/views.py:2461
 msgid "Cannot edit a plan you don't own."
 msgstr "他のユーザの計画案は編集できません。"
 
-#: redistricting/views.py:2476 redistricting/views.py:2509
+#: redistricting/views.py:2478 redistricting/views.py:2511
 msgid "Must declare planId"
 msgstr "計画案IDの指定が必要です"
 
-#: redistricting/views.py:2484
+#: redistricting/views.py:2486
 msgid "Deleted plan"
 msgstr "計画案を削除しました"
 
-#: redistricting/views.py:2486
+#: redistricting/views.py:2488
 msgid "Failed to delete plan"
 msgstr "計画案が削除できませんでした"
 
-#: redistricting/views.py:2491
+#: redistricting/views.py:2493
 msgid "Cannot delete a plan you don't own."
 msgstr "他のユーザの計画案は削除できません。"
 
-#: redistricting/views.py:2523
+#: redistricting/views.py:2525
 msgid "Reaggregating plan"
 msgstr "計画案を再統合しています"
 
-#: redistricting/views.py:2525
+#: redistricting/views.py:2527
 msgid "Failed to reaggregate plan"
 msgstr "計画案の再統合に失敗しました"
 
-#: redistricting/views.py:2530
+#: redistricting/views.py:2532
 msgid "Cannot reaggregate a plan you don't own."
 msgstr "他のユーザの計画案は再統合できません"
 
-#: redistricting/views.py:2554
+#: redistricting/views.py:2556
 #, python-format
 msgid "Health retrieved at %(time)s\n"
 msgstr "プログラム状況取得時刻: %(time)s\n"
 
-#: redistricting/views.py:2555
+#: redistricting/views.py:2557
 #, python-format
 msgid "%(plan_count)d plans in database\n"
 msgstr "データベースには%(plan_count)d個の計画案があります\n"
 
-#: redistricting/views.py:2557
+#: redistricting/views.py:2559
 #, python-format
 msgid "%(session_count)d sessions in use out of %(session_limit)s\n"
 msgstr ""
 "%(session_limit)s個のうち%(session_count)d個のセッションを利用中です。\n"
 
-#: redistricting/views.py:2560
+#: redistricting/views.py:2562
 #, python-format
 msgid "%(num_users)d active users over the last 10 minutes\n"
 msgstr "最新10分間内のｱｸﾃｨﾌﾞﾕｰｻﾞｰ数: %(num_users)d人\n"
 
-#: redistricting/views.py:2563
+#: redistricting/views.py:2565
 #, python-format
 msgid "%(mb_free)s MB of disk space free\n"
 msgstr "空ﾃﾞｨｽｸｽﾍﾟｰｽ: %(mb_free)s MB\n"
 
-#: redistricting/views.py:2565
+#: redistricting/views.py:2567
 #, python-format
 msgid ""
 "Memory Usage:\n"
@@ -2765,7 +2765,7 @@ msgstr ""
 "メモリ使用量:\n"
 "%(mem_free)s\n"
 
-#: redistricting/views.py:2570
+#: redistricting/views.py:2572
 #, python-format
 msgid ""
 "ERROR! Couldn't get health:\n"
@@ -2774,25 +2774,25 @@ msgstr ""
 "エラー！プログラム状況が取得できませんでした:\n"
 "%s"
 
-#: redistricting/views.py:2578
+#: redistricting/views.py:2580
 msgid "No plan with that ID exists."
 msgstr "そのIDの計画案はありません。"
 
-#: redistricting/views.py:2637
+#: redistricting/views.py:2639
 #, python-format
 msgid "No functions for %(panel)s"
 msgstr "%(panel)sの機能はありません"
 
-#: redistricting/views.py:2646
+#: redistricting/views.py:2648
 #, python-format
 msgid "No user displays for %(user)s"
 msgstr "%(user)sのﾕｰｻﾞｰﾃﾞｨｽﾌﾟﾚｲはありません"
 
-#: redistricting/views.py:2668
+#: redistricting/views.py:2670
 msgid "Couldn't delete personalized scoredisplay"
 msgstr "個人用のscoredisplayを削除できませんした"
 
-#: redistricting/views.py:2720
+#: redistricting/views.py:2722
 #, python-format
 msgid ""
 "Each user is limited to %(limit)d statistics sets. Please delete one or edit "
@@ -2801,11 +2801,11 @@ msgstr ""
 "ユーザ１名につき%(limit)d個までの統計しか使えません。削除をするか現存する統計"
 "を編集してください。"
 
-#: redistricting/views.py:2738
+#: redistricting/views.py:2740
 msgid "Didn't get functions in POST parameter"
 msgstr "POST parameterの機能を取得できませんでした"
 
-#: redistricting/views.py:2774
+#: redistricting/views.py:2776
 msgid "No plan with that ID was found."
 msgstr "そのIDの計画案は見つかりませんでした。"
 

--- a/django/publicmapping/redistricting/management/commands/makelanguagefiles.py
+++ b/django/publicmapping/redistricting/management/commands/makelanguagefiles.py
@@ -87,7 +87,7 @@ class Command(BaseCommand):
                 management.call_command(
                     'makemessages',
                     locale=[locale],
-                    extensions=['html', 'txt', 'email'],
+                    extensions=['html', 'txt', 'email', 'py'],
                     interactive=False,
                     verbosity=options.get('verbosity'),
                     ignore_patterns=['static/jquery/*.*'])

--- a/django/publicmapping/redistricting/templates/admin.email
+++ b/django/publicmapping/redistricting/templates/admin.email
@@ -19,7 +19,7 @@ Context:
 {% trans "There was a problem importing a plan file from user" %} '{{ user.username }}'. {% trans "This user attempted to upload a file containing a plan but had some trouble.  The plan may have been imported." %}
 
 {% if plan %}
-{% trans "Plan name" %}: {{ plan.name }}
+{% trans "Plan Name" %}: {{ plan.name }}
 {% endif %}
 
 {% for error in errors %}

--- a/django/publicmapping/redistricting/templates/submission.email
+++ b/django/publicmapping/redistricting/templates/submission.email
@@ -10,9 +10,9 @@ Context:
 {% load i18n %}
 {% autoescape off %}
 {% trans "user name" %}: {{ user.username }}
-{% trans "plan id" %}:  {{ plan.pk }}
-{% trans "plan version" %}: {{ plan.version }}
-{% trans "plan name" %}: {{ plan.name }}
+{% trans "Plan id" %}:  {{ plan.pk }}
+{% trans "Plan version" %}: {{ plan.version }}
+{% trans "Plan Name" %}: {{ plan.name }}
 {% trans "legislative body" %}: {{ plan.legislative_body.name }}
 {% for key,value in post.items %}{{ key }}: {{ value }}
 {% endfor %}

--- a/django/publicmapping/redistricting/templates/submitted.email
+++ b/django/publicmapping/redistricting/templates/submitted.email
@@ -11,7 +11,7 @@ Context:
 {% autoescape off %}
 {% trans "Hello" %} {{ user.username }},
 
-{% trans "Your plan" %} ("{{ plan.name }}") {% trans "has been successfully submitted. Thank you for your submission." %}
+{% trans "Your Plan" %} ("{{ plan.name }}") {% trans "has been successfully submitted. Thank you for your submission." %}
 
 {% trans "Happy Redistricting!" %}
 {% trans "The Public Mapping Team" %}


### PR DESCRIPTION
## Overview

This fixes issues with the a translations PR that was recently merged (https://github.com/azavea/district-builder-dtl-pa/pull/47). 

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

### Notes

Translations were working fine before -- I was just doing it wrong.

The way Django translations work is you run `makemessages` and Django looks through whatever files you tell it to look in (in our case namely Python files and templates; see `makelanguagefiles.py`) for text that needs to be translated. It then makes changes to your `.po` files to reflect what text needs to be translated in the files it looked in. Then you update the `.po` files with translations strings. Then you compile them with `compilemessages` and that is what Django uses.

We do all of this in one straight shot in our `makelanguagefiles` command which runs automatically when the containers start up. If your `.po` files are correct, everything works great. If there are issues, it does not. For me, since I hadn't `rsync-back`d the `.po` files, GNU gettext (what Django uses under the covers) got confused since there were missing translations (when translation keys don't exactly match up it will mark them as `fuzzy` and not display those; this happened with the `msgid` of "plan" which resulted in that not being translated; since it is used all of the place many translations were missing). 

## Testing Instructions

As long as `rsync-auto` is on, just check out the branch and restart the server.
