### PR TITLE
Remove unnecessary variables from Terraform config

### DIFF
--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -21,23 +21,3 @@ variable "ssl_certificate_arn" {}
 variable "cdn_price_class" {
   default = "PriceClass_100"
 }
-
-variable "districtbuilder_database_name" {}
-
-variable "districtbuilder_web_app_password" {}
-
-variable "districtbuilder_admin_user" {}
-
-variable "districtbuilder_admin_email" {}
-
-variable "districtbuilder_admin_password" {}
-
-variable "districtbuilder_redis_password" {}
-
-variable "districtbuilder_geoserver_password" {}
-
-variable "districtbuilder_mailer_host" {}
-
-variable "districtbuilder_mailer_user" {}
-
-variable "districtbuilder_mailer_password" {}


### PR DESCRIPTION
## Overview

When working on PublicMapping/DistrictBuilder/pull/552, I noticed that there were some unnecessary Terraform variables. This PR cleans them up (and I've removed them from the file on S3)

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Files changed in the PR have been `yapf`-ed for style violations~

## Testing Instructions
* Apply the following diff:
```diff
diff --git a/docker-compose.ci.yml b/docker-compose.ci.yml
index 60d3eca4..f36caf03 100644
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -7,8 +7,7 @@ services:
     working_dir: /usr/local/src
     entrypoint: bash
     environment:
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_PROFILE=district-builder
       - AWS_REGION=${AWS_REGION:-us-east-1}
       - DB_DEBUG=1
       - IMAGE_VERSION=${IMAGE_VERSION:-latest}
@@ -17,3 +16,4 @@ services:
     volumes:
       - ./:/usr/local/src
       - ~/.ssh:/root/.ssh
+      - ~/.aws:/root/.aws
```
 * run `scripts/infra plan`, ensure that a change to the app-server instance type appears in the plan
```bash
# Set up AWS profile, if it doesn't already exist
$ aws --profile district-builder configure
$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

data.template_file.user_data: Refreshing state...
data.terraform_remote_state.core: Refreshing state...
data.aws_ami.ecs_ami: Refreshing state...
data.aws_route53_zone.external: Refreshing state...
aws_instance.app_server: Refreshing state... (ID: i-08355a3ea5fe5b3b0)
null_resource.provision_app_server: Refreshing state... (ID: 6015103681935556586)
aws_route53_record.origin: Refreshing state... (ID: Z1FT5I1ZDZZ6S_origin.pa.districtbuilder.azavea.com_CNAME)
aws_cloudfront_distribution.cdn: Refreshing state... (ID: EMAFR9O3MGA5R)
aws_route53_record.app: Refreshing state... (ID: Z1FT5I1ZDZZ6S_pa.districtbuilder.azavea.com._A)

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

  ~ aws_instance.app_server
      instance_type: "t2.small" => "m5.large"

-/+ null_resource.provision_app_server (new resource required)
      id:            "6015103681935556586" => <computed> (forces new resource)
      triggers.%:    "1" => "1"
      triggers.uuid: "76e33514-dedb-1133-c1eb-527c8d97b8e6" => "62434aa8-e640-83cf-6222-c96787439194" (forces new resource)


Plan: 1 to add, 1 to change, 1 to destroy.

------------------------------------------------------------------------

This plan was saved to: districtbuilder-staging-config-us-east-1.tfplan

To perform exactly these actions, run the following command to apply:
    terraform apply "districtbuilder-staging-config-us-east-1.tfplan"
```
Connects PublicMapping/DistrictBuilder/pull/552
