### PR TITLE
Remove district thematic map shading

### DIFF
--- a/django/publicmapping/redistricting/calculators.py
+++ b/django/publicmapping/redistricting/calculators.py
@@ -1433,7 +1433,7 @@ class Interval(CalculatorBase):
         if not self.result is None and 'value' in self.result:
             if 'index' in self.result and 'subject' in self.result:
                 interval = self.result['index']
-                interval_class = "interval_%d" % interval if interval >= 0 else 'no_interval'
+                interval_class = 'no_interval'
                 t = '<span class="{{ class }} {{ result.subject }}">' \
                     '{{ result.value|floatformat:0 }}</span>'
                 c = {'class': interval_class}

--- a/django/publicmapping/redistricting/calculators.py
+++ b/django/publicmapping/redistricting/calculators.py
@@ -1433,7 +1433,7 @@ class Interval(CalculatorBase):
         if not self.result is None and 'value' in self.result:
             if 'index' in self.result and 'subject' in self.result:
                 interval = self.result['index']
-                interval_class = 'no_interval'
+                interval_class = "interval_%d" % interval if interval >= 0 else 'no_interval'
                 t = '<span class="{{ class }} {{ result.subject }}">' \
                     '{{ result.value|floatformat:0 }}</span>'
                 c = {'class': interval_class}

--- a/django/publicmapping/redistricting/templates/viewplan.html
+++ b/django/publicmapping/redistricting/templates/viewplan.html
@@ -1003,7 +1003,7 @@ Include the shared_districts markup if we're using the copy/paste tool
             </div>
 
 
-            <div class="dialog_step" {% if plan.is_community %}style="display: none;"{% endif %}>
+            <div class="dialog_step" style="display: none;">
                 <h2>2. {% trans "Choose District Thematic Map" %}</h2>
                 {% comment %}
 
@@ -1013,7 +1013,7 @@ Include the shared_districts markup if we're using the copy/paste tool
 
                 {% endcomment %}
                 <select id="districtby" class="indented fillwidth" autocomplete="off">
-                    <option value="0" name="None">{% trans "None" %}</option>
+                    <option value="0" name="None" selected="true">{% trans "None" %}</option>
                     <option value="-1" name="Compactness">{% trans "Compactness" %}</option>
                     <option value="-2" name="Contiguity">{% trans "Contiguity" %}</option>
                     {% if adjacency %}
@@ -1024,7 +1024,7 @@ Include the shared_districts markup if we're using the copy/paste tool
                     {% endif %}
                     {% for demo in demographics %}
                         {% if demo.isdisplayed == "true" %}
-                            <option value="{{ demo.id }}" name="{{ demo.value }}" {% if demo.isdefault == "true" %}selected="true"{% endif %}>
+                            <option value="{{ demo.id }}" name="{{ demo.value }}">
                                 {{ demo.text }}
                             </option>
                         {% endif %}
@@ -1033,7 +1033,7 @@ Include the shared_districts markup if we're using the copy/paste tool
             </div>
 
             <div class="dialog_step">
-              <h2>{% if plan.is_community %}2{% else %}3{% endif %}. {% trans "Choose a Reference Layer" %}</h2>
+              <h2>2. {% trans "Choose a Reference Layer" %}</h2>
               <select id="reference_layer_select" class="indented fillwidth" autocomplete="off">
                   <option value="None">{% trans "None" %}</option>
                   {% for snap in snaplayers %}


### PR DESCRIPTION
## Overview

Remove district thematic map shading and teal/yellow colors from demographics panel.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

### Demo

<img width="1680" alt="screen shot 2018-07-12 at 2 13 09 pm" src="https://user-images.githubusercontent.com/3959096/42651569-c4155bbe-85dd-11e8-87e1-e89047cc1f76.png">

<img width="1680" alt="screen shot 2018-07-12 at 2 13 15 pm" src="https://user-images.githubusercontent.com/3959096/42651572-c6d83c90-85dd-11e8-8361-91a79ad165ab.png">

## Testing Instructions

 * Start server and log in
 * Go to Draw
 * Check to see that map does not have teal/yellow district shading.
 * Check to see that map legend does not have teal/yellow colors.
 * Check to see that demographics sidebar does not have teal/yellow colors.
 * Click "Set Map Layers" and check to see that "Choose District Thematic Map" panel isn't visible. 
