### PR TITLE
Make default reference layer county

### DIFF
--- a/django/publicmapping/static/js/layerchooser.js
+++ b/django/publicmapping/static/js/layerchooser.js
@@ -112,6 +112,9 @@ layerchooser = function(options) {
             _options.referenceLayerLabelsWrapper.toggle(DB.util.startsWith(selector.val(), "plan"))
         });
 
+        _options.referenceLayerSelect.val('geolevel.4');
+        _options.referenceLayerSelect.trigger('change');
+
         // Trigger event when the show reference layer labels checkbox changes
         _options.referenceLayerLabelsCheck.click(function() {
             _options.map.trigger('reference_layer_labels_checked', [$(this).is(':checked')]);


### PR DESCRIPTION
## Overview

Make the default reference layer `county` instead of no reference layer by default.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

### Demo

<img width="1680" alt="screen shot 2018-07-12 at 3 16 25 pm" src="https://user-images.githubusercontent.com/3959096/42654487-c8ec96a8-85e6-11e8-8667-05c3713c3432.png">

## Testing Instructions

 * Start server and go to map
 * See that the map loads with counties as the reference layer (green outlines)
 * See that on clicking "See Map Layers" the chosen value is `county`