### PR TITLE
Add white halo to map labels for readability

### DIFF
--- a/django/publicmapping/static/js/mapping.js
+++ b/django/publicmapping/static/js/mapping.js
@@ -619,7 +619,9 @@ function mapinit(srs,maxExtent) {
         fontSize: '10pt',
         fontFamily: 'Arial,Helvetica,sans-serif',
         fontWeight: '800',
-        labelAlign: 'cm'
+        labelAlign: 'cm',
+        labelOutlineColor: 'white',
+        labelOutlineWidth: '3'
     };
 
     // The style for the highlighted district layer


### PR DESCRIPTION
## Overview

Makes District labels more easily readable.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

Before
<img width="572" alt="screen shot 2018-07-12 at 3 14 04 pm" src="https://user-images.githubusercontent.com/447977/42654397-7a38db3e-85e6-11e8-9b3c-9411ddda4532.png">
After
<img width="563" alt="screen shot 2018-07-12 at 3 14 28 pm" src="https://user-images.githubusercontent.com/447977/42654401-7f9bdde2-85e6-11e8-92e8-ad91b13618b0.png">

## Testing Instructions

 * Load up any map and see that the labels now have white halos around them and are easily readable on all types of backgrounds.

Closes #158993075
