### PR TITLE
Change order of opacity slider and basemap picker and add labels #158995111

### DIFF
--- a/django/publicmapping/redistricting/templates/viewplan.html
+++ b/django/publicmapping/redistricting/templates/viewplan.html
@@ -519,8 +519,14 @@
           </div>
 
           <div id="map_settings_content">
-             <div id="map_type_content_container"></div>
-            <div id="opacity_slider"></div>
+            <div>
+              <label>Opacity</label>
+              <div id="opacity_slider" style="display: inline-block; width: 50%;"></div>
+            </div>
+            <div>
+              <label>Basemap</label>
+              <div id="map_type_content_container" style="display: inline-block;"></div>
+            </div>
             <div id="reference_layer_id" class="layer_type_container">
                 <div id="reference_layer_label">{% trans "Reference Layer:" %}</div>
                 <div id="reference_layer_name">{% trans "None" %}</div>


### PR DESCRIPTION
## Overview

Change order of opacity slider and basemap picker and add labels

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- ~[ ] Files changed in the PR have been `yapf`-ed for style violations~

### Notes

CSS will be added later by a designer. For now some minimal CSS was added inline.

## Testing Instructions

* If server is not running, `./scripts/server`
* If running, `docker-compose restart django`

Closes #158995111
