### PR TITLE
Fix translations on staging

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -34,7 +34,3 @@ services:
   geoserver:
     links:
       - postgres:${DATABASE_HOST}
-
-  languages:
-    volumes:
-      - ./django/publicmapping/:/usr/src/app/

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -50,15 +50,3 @@ services:
       driver: syslog
       options:
         tag: districtbuilder-geoserver
-
-  languages:
-    image: districtbuilder-languages:${GIT_COMMIT:-latest}
-    container_name: districtbuilder-languages
-    restart: on-failure
-    volumes:
-      - /opt/district-builder/user-data/config_settings.py:/usr/src/app/publicmapping/config_settings.py
-      - /opt/district-builder/user-data/config.xml:/usr/src/app/config/config.xml
-    logging:
-      driver: syslog
-      options:
-        tag: districtbuilder-languages

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,18 +80,6 @@ services:
     ports:
       - "${MAP_SERVER_PORT}:${WEB_APP_PORT}"
 
-  languages:
-    build:
-      context: ./django/publicmapping
-    env_file:
-      - .env
-    entrypoint: /usr/local/bin/python
-    command:
-      - "manage.py"
-      - "makelanguagefiles"
-    depends_on:
-      - django
-
 volumes:
   reports:
   data:

--- a/scripts/update
+++ b/scripts/update
@@ -44,6 +44,12 @@ function write_settings() {
 
 }
 
+function make_translations() {
+    echo "Create and compile translations"
+    docker-compose \
+        exec -T django ./manage.py makelanguagefiles
+}
+
 function change_geoserver_admin_password() {
     docker-compose \
         exec -T geoserver ./bin/change_admin_password.sh
@@ -74,6 +80,7 @@ then
         docker-compose up -d "${MIGRATION_CONTAINERS[@]}"
         run_migrations
         reconfigure
+        make_translations
         change_geoserver_admin_password
     fi
     exit


### PR DESCRIPTION
## Overview

Gets rid of the `languages` container in favor of making translations on update.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- ~~[ ] Files changed in the PR have been `yapf`-ed for style violations~~

### Notes

On staging, the `django.mo` and `djangojs.mo` files were missing:

```
root@87657c9f6aac:/usr/src/app# ls -l locale/en/LC_MESSAGES/
total 224
-rw-rw-r-- 1 root root 75265 Jul 16 18:49 django.po
-rw-rw-r-- 1 root root 21608 Jul 16 18:49 djangojs.po
-rw-r--r-- 1 root root 38667 Jul 16 18:58 xmlconfig.mo
-rw-rw-r-- 1 root root 83376 Jul 16 18:58 xmlconfig.po
```

It's not entirely clear why this is so. Translations are supposed to be compiled whenever the containers are spun up. The way deployment is currently that doesn't seem to be happening.

This PR moves the making of translations into `scripts/update`. This seems like a good place for it since it really only need to be run when upon update, which happens on every deploy.

## Testing Instructions

I tested this PR by telling Jenkins to deploy to staging whenever this branch is pushed to, so staging should have correct translations already. Verify that this is the case (there should be no occurrences of "plan", only "map").

Closes #159006102
