### PR TITLE
Add total county splits to submission summary page

### DIFF
--- a/django/publicmapping/config/config.xml
+++ b/django/publicmapping/config/config.xml
@@ -421,6 +421,16 @@
                 <Argument name="target" value="18"/>
             </ScoreFunction>
 
+            <ScoreFunction id="congress_plan_splits_count" type="plan"
+                calculator="redistricting.calculators.SplitCounter"
+                label="Split Counties"
+                description="The number of counties that are split by a district within the plan."
+            >
+                <!-- 2 is the County level for this config -->
+                <Argument name="boundary_id" value="geolevel.2" />
+                <Argument name="only_total" value="1" />
+            </ScoreFunction>
+
             <ScoreFunction id="congress_plan_polsbypopper" type="plan"
                 calculator="redistricting.calculators.PolsbyPopper"
                 label="Average Compactness"
@@ -537,6 +547,18 @@
                 <Score ref="district_polsbypopper" />
             </ScorePanel>
 
+	    <!-- Submission One-page Summary -->
+            <ScorePanel id="plan_submission_summary" type="plan_summary" position="1"
+                title="Plan Summary" cssclass="plan_summary congressional" template="plan_summary.html">
+                <Score ref="congress_plan_equipopulation_summary"/>
+                <Score ref="congress_plan_noncontiguous"/>
+                <Score ref="congress_plan_polsbypopper"/>
+                <Score ref="congress_plan_equivalence"/>
+                <Score ref="congress_plan_competitiveness"/>
+                <Score ref="congress_plan_vapnownh_thresh"/>
+                <Score ref="congress_plan_splits_count" />
+            </ScorePanel>
+
             <!-- Demographics -->
             <ScorePanel id="congressional_panel_demo" type="district" position="2"
                 title="Demographics" cssclass="district_demographics congressional"
@@ -578,6 +600,11 @@
                 <ScorePanel ref="panel_compact_mine" />
                 <ScorePanel ref="panel_equivalence_mine" />
                 <ScorePanel ref="panel_competitiveness_mine" />
+            </ScoreDisplay>
+
+            <ScoreDisplay id="congress_submission_summary" legislativebodyref="congress" type="sidebar"
+                title="Split Counties">
+                <ScorePanel ref="plan_submission_summary" />
             </ScoreDisplay>
 
              <!-- Sidebar configuration -->

--- a/django/publicmapping/redistricting/calculators.py
+++ b/django/publicmapping/redistricting/calculators.py
@@ -210,7 +210,7 @@ class CalculatorBase(object):
                 except:
                     # No problem, it may be a string
                     pass
-        elif argtype == 'subject' and not district is None:
+        elif argtype == 'subject' and district is not None:
             # This method is more fault tolerant than _set.get, since it
             # won't throw an exception if the item doesn't exist.
             add_subject = True
@@ -2399,9 +2399,9 @@ class DistrictSplitCounter(CalculatorBase):
         Calculate splits between a district and a target geolevel.
 
         @keyword district: A L{District} whose splits should be computed.
-        @keyword boundary_id: The ID of the geolevel to compare for splits.
+        @keyword geolevel_id: The ID of the geolevel to compare for splits.
         """
-        if not 'district' in kwargs:
+        if 'district' not in kwargs:
             return
 
         district = kwargs['district']

--- a/django/publicmapping/redistricting/templates/submission_summary.html
+++ b/django/publicmapping/redistricting/templates/submission_summary.html
@@ -42,11 +42,13 @@
     </div>
     <div class="explanations">
       <ul>
-        <li><a href="#">Compactness</a></li>
-        <li><a href="#">Equipopulation</a></li>
         <li><a href="#">Competitiveness</a></li>
-        <li><a href="#">Splits</a></li>
-        <li><a href="#">Majority minority districts</a></li>
+        <li><a href="#">Target Population</a></li>
+        <li><a href="#">Equal Population</a></li>
+        <li><a href="#">Contiguous</a></li>
+        <li><a href="#">Compactness</a></li>
+        <li><a href="#">Split Counties</a></li>
+        <li><a href="#">Majority-Minority districts</a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
## Overview

Adds a line for county splits to the submission summary one-page report.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] ~Files changed in the PR have been `yapf`-ed for style violations~

### Demo

<img width="361" alt="screen shot 2018-07-19 at 12 19 25 pm" src="https://user-images.githubusercontent.com/447977/42956459-00bff572-8b4e-11e8-8b4b-5573a47ee93b.png">


## Testing Instructions

 * I _think_ it should be safe to simply run `./manage.py setup config/config.xml`, but to be on the safe side, I suggest opening a Django shell and running `ScorePanel.objects.all().delete()` and `ScoreFunction.objects.all().delete()`, and then run the setup command afterward.
 * Follow the instructions for testing #36 
 * Confirm that there is a new line displayed, for the number of split counties.
 * Use the "Splits Report" feature of the mapping UI to confirm that the reported number of splits matches up with what the "Splits Report" outputs. 


Closes #158292949
