### PR TITLE
Add tooltips to explain download buttons on plan/map page

### DIFF
--- a/django/publicmapping/static/js/districtfile.js
+++ b/django/publicmapping/static/js/districtfile.js
@@ -101,10 +101,10 @@ districtfile = function(options) {
             var fileStatus = data.status,
                 button;
             if (_options.type == 'index') {
-                button = $('<button type="button" id="btnExportDistrictIndexFile" class="button" />');
+                button = $('<button type="button" id="btnExportDistrictIndexFile" title="Downloads a zipped .csv file that maps census tracts to districts for this map." class="button" />');
             }
             else {
-                button = $('<button type="button" id="btnExportDistrictShapeFile" class="button" />');
+                button = $('<button type="button" id="btnExportDistrictShapeFile" title="Downloads a zipped ESRI shapefile (.shp) of this map that can be viewed in GIS software." class="button" />');
             };
             
 


### PR DESCRIPTION
## Overview

Add tooltips to explain download buttons on plan/map page.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

 * Log in and go to map page. Select a map. Hover over the download buttons on the bottom right and confirm that the tooltips show up. 
 * Here's the text you should looking for `Downloads a zipped .csv file that maps census tracts to districts for this map.` for the `Request Index File` button and `Downloads a zipped ESRI shapefile (.shp) of this map that can be viewed in GIS software.` for the `Request Shapefile` button.

Closes #159331229
