### PR TITLE
Fix timestamp bugs

### DIFF
--- a/django/publicmapping/redistricting/views.py
+++ b/django/publicmapping/redistricting/views.py
@@ -437,7 +437,6 @@ def commonplan(request, planid):
     plan = Plan.objects.filter(id=planid)
     if plan.count() == 1:
         plan = plan[0]
-        plan.edited = getutc(plan.edited)
         levels = plan.legislative_body.get_geolevels()
         districts = plan.get_districts_at_version(
             plan.version, include_geom=False)
@@ -1179,7 +1178,7 @@ def newdistrict(request, planid):
                 status['success'] = True
                 status['message'] = _('Created 1 new district')
                 plan = Plan.objects.get(pk=planid, owner=request.user)
-                status['edited'] = getutc(plan.edited).isoformat()
+                status['edited'] = plan.edited.isoformat()
                 status['district_id'] = district_id
                 status['version'] = plan.version
             except ValidationError:
@@ -1641,7 +1640,7 @@ def addtodistrict(request, planid, districtid):
                 % {'num_fixed_districts': fixed}
             status['updated'] = fixed
             plan = Plan.objects.get(pk=planid, owner=request.user)
-            status['edited'] = getutc(plan.edited).isoformat()
+            status['edited'] = plan.edited.isoformat()
             status['version'] = plan.version
         except Exception, ex:
             status['exception'] = traceback.format_exc()

--- a/django/publicmapping/static/js/mapping.js
+++ b/django/publicmapping/static/js/mapping.js
@@ -3068,6 +3068,7 @@ function mapinit(srs,maxExtent) {
 
                     var updateAssignments = true;
                     $('#map').trigger('version_changed', [data.version, updateAssignments]);
+                    $('#saveplaninfo').trigger('planSaved', [ data.edited ]);
 
 
                     $('#working').dialog('close');


### PR DESCRIPTION
## Overview

The timestamp on the bottom of the Draw page was showing what appeared to be PT instead of ET. This fix makes sure it shows the local time of the server, which will be ET or EST as needed. This also makes a fix to update the timestamp when a new district is created. Currently, the timestamp is only updated when a geounit is reassigned to an existing district. 

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

 * Create a new map (from a template, say) and find yourself in the Draw tab. 
 * Look at the timestamp. It should be the created time in Eastern.
 * Wait till the minute changes. 
 * Assign a geounit to an existing district. Verify that the timestamp updates.
 * Refresh and verify the time still persists. 
 * Wait till the minute changes. 
 * Assign a geounit to a brand new district (to do this you might have to assign all geounits of a district to another one entirely so that district vanishes). Verify that the timestamp updates.

Closes #159309096
