### PR TITLE
Update deployment README

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -14,7 +14,7 @@ services:
       - IMAGE_VERSION=${IMAGE_VERSION:-latest}
       - DB_STATE=${DB_STATE:-pa}
       - DB_SETTINGS_BUCKET=${DB_SETTINGS_BUCKET:-district-builder-dtl-staging-config-us-east-1}
-      - DOCKER_HOST=${DOCKER_HOST:-origin.staging.pa.districtbuilder.azavea.com:2476}
+      - DB_DOCKER_HOST=${DB_DOCKER_HOST:-origin.staging.pa.districtbuilder.azavea.com:2476}
     volumes:
       - ./:/usr/local/src
       - ~/.ssh:/root/.ssh

--- a/scripts/infra
+++ b/scripts/infra
@@ -76,7 +76,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                     rm "client.zip"
 
                     export DOCKER_TLS_VERIFY=1
-                    export DOCKER_HOST="${DOCKER_HOST}"
+                    export DOCKER_HOST="${DB_DOCKER_HOST}"
                     export DOCKER_CERT_PATH="/root/.docker"
 
                     set +e


### PR DESCRIPTION
## Overview

Updates deployment instructions to reflect the change to a new AWS account/SSH keypair. Additionally, change `DOCKER_HOST` to `DB_DOCKER_HOST` in `docker-compose.ci.yml` to avoid accidentally overriding the deployment environment's `DOCKER_HOST` when running Production deployments.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions
* Verify that the changes made to the `README` are accurate.
