### PR TITLE
Change copy for side panel

### DIFF
--- a/django/publicmapping/config/config.xml
+++ b/django/publicmapping/config/config.xml
@@ -425,7 +425,7 @@
 
             <ScoreFunction id="congress_plan_equipopulation_validation" type="plan"
                 calculator="redistricting.calculators.Equipopulation"
-                label="Target Pop. (702,160 - 709,216)"
+                label="Target Population (705,688)"
                 description="The population of each Congressional district must be 705,688 +/- 0.5%.">
                 <Argument name="min" value="702160"/>
                 <Argument name="max" value="709216"/>
@@ -435,7 +435,7 @@
 
             <ScoreFunction id="A_congress_plan_equipopulation_summary" type="plan"
                 calculator="redistricting.calculators.Equipopulation"
-                label="Target Pop. (702,160 - 709,216)"
+                label="Target Population (705,688)"
                 description="The population of each Congressional district must be 705,688 +/- 0.5%.">
                 <Argument name="min" value="702160"/>
                 <Argument name="max" value="709216"/>
@@ -491,13 +491,13 @@
 
             <ScoreFunction id="E_congress_plan_polsbypopper" type="plan"
                 calculator="redistricting.calculators.PolsbyPopper"
-                label="Avg. Compactness (100% is best)"
+                label="Compactness"
                 description="The competition is using the &apos;Polsby-Popper&apos; compactness measure. This measure is a ratio of the area of a circle with the same perimeter as a district to the area of the district." >
             </ScoreFunction>
 
             <ScoreFunction id="F_congress_plan_equivalence" type="plan"
                 calculator="redistricting.calculators.Equivalence"
-                label="Pop. Equivalence (0 is best)"
+                label="Population Equivalence"
                 description="The Equipopulation score is the difference between the district with the highest population and the district with the lowest population.">
                 <SubjectArgument name="value" ref="poptot" />
             </ScoreFunction>

--- a/django/publicmapping/locale/en/LC_MESSAGES/django.po
+++ b/django/publicmapping/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-31 16:46-0400\n"
+"POT-Creation-Date: 2018-08-08 12:39-0400\n"
 "PO-Revision-Date: 2012-11-06 16:01-0600\n"
 "Last-Translator: David Zwarg <dzwarg@azavea.com>\n"
 "Language-Team: Azavea <info@azavea.com>\n"
@@ -1119,7 +1119,7 @@ msgid "Thank you."
 msgstr ""
 
 #: redistricting/templates/basic_information.html:44
-#: redistricting/templates/competitiveness.html:44
+#: redistricting/templates/competitiveness.html:13
 #: redistricting/templates/demographics.html:44
 msgid "Dist."
 msgstr ""
@@ -1127,7 +1127,6 @@ msgstr ""
 #: redistricting/templates/basic_information.html:64
 #: redistricting/templates/communities.html:61
 #: redistricting/templates/community_demographics.html:61
-#: redistricting/templates/competitiveness.html:64
 #: redistricting/templates/demographics.html:64
 msgid "Sorry, there is no demographic data for this plan"
 msgstr "Sorry, there is no demographic data for this map"
@@ -1174,7 +1173,7 @@ msgstr ""
 msgid "Community"
 msgstr ""
 
-#: redistricting/templates/competitiveness.html:64
+#: redistricting/templates/competitiveness.html:33
 #, fuzzy
 #| msgid "Sorry, there is no demographic data for this plan"
 msgid "Sorry, there is no competitiveness data for this plan"

--- a/django/publicmapping/locale/en/LC_MESSAGES/xmlconfig.po
+++ b/django/publicmapping/locale/en/LC_MESSAGES/xmlconfig.po
@@ -2400,11 +2400,11 @@ msgstr "county"
 
 #: /usr/src/app/config/config.xml:427
 msgid "congress_plan_polsbypopper short label"
-msgstr "Avg. Compactness (100% is best)"
+msgstr "Compactness"
 
 #: /usr/src/app/config/config.xml:427
 msgid "congress_plan_polsbypopper label"
-msgstr "Avg. Compactness (100% is best)"
+msgstr "Compactness"
 
 #: /usr/src/app/config/config.xml:427
 msgid "congress_plan_polsbypopper long description"
@@ -2427,11 +2427,11 @@ msgstr ""
 
 #: /usr/src/app/config/config.xml:433
 msgid "congress_plan_equivalence short label"
-msgstr "Pop. Equivalence (0 is best)"
+msgstr "Population Equivalence"
 
 #: /usr/src/app/config/config.xml:433
 msgid "congress_plan_equivalence label"
-msgstr "Pop. Equivalence (0 is best)"
+msgstr "Population Equivalence"
 
 #: /usr/src/app/config/config.xml:433
 msgid "congress_plan_equivalence long description"
@@ -2496,11 +2496,11 @@ msgstr ""
 
 #: /usr/src/app/config/config.xml:381
 msgid "congress_plan_equipopulation_summary short label"
-msgstr "Target Pop. (702,160 - 709,216)"
+msgstr "Target Population (705,688)"
 
 #: /usr/src/app/config/config.xml:381
 msgid "congress_plan_equipopulation_summary label"
-msgstr "Target Pop. (702,160 - 709,216)"
+msgstr "Target Population (705,688)"
 
 #: /usr/src/app/config/config.xml:381
 msgid "congress_plan_equipopulation_summary long description"
@@ -2985,11 +2985,11 @@ msgstr ""
 
 #: /usr/src/app/config/config.xml:371
 msgid "congress_plan_equipopulation_validation short label"
-msgstr "Target Pop. (702,160 - 709,216)"
+msgstr "Target Population (705,688)"
 
 #: /usr/src/app/config/config.xml:371
 msgid "congress_plan_equipopulation_validation label"
-msgstr "Target Pop. (702,160 - 709,216)"
+msgstr "Target Population (705,688)"
 
 #: /usr/src/app/config/config.xml:371
 msgid "congress_plan_equipopulation_validation long description"


### PR DESCRIPTION
## Overview

Update copy.

The copy was changed as part of a larger set of config changes in https://github.com/azavea/district-builder-dtl-pa/pull/65 but the text was wrapping and didn't look great so C70 changed it again.
### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

### Screenshot

Should look like this now:
![side_panel_new_copy](https://user-images.githubusercontent.com/2926237/43851737-8af7e52c-9b09-11e8-8657-055b8cf892e5.png)

## Testing Instructions

`./scripts/update && ./scripts/server`
