### PR TITLE
Change header text and add sentence to explain upload map

### DIFF
--- a/django/publicmapping/redistricting/templates/editplan.html
+++ b/django/publicmapping/redistricting/templates/editplan.html
@@ -171,7 +171,7 @@
                 <h3>Did you know?</h3>
                 <ul>
                     <p> • You can see how your map stacks up against others by checking out the Leaderboards page.</p>
-                    <p> • If you want to make changes to your map, just use the button at the top to head back to the Draw page.</p>
+                    <p> • If you want to make changes to your map, just use the button at the top to head back to the Map page.</p>
                 </ul>
             </div>
         </div>

--- a/django/publicmapping/redistricting/templates/viewplan.html
+++ b/django/publicmapping/redistricting/templates/viewplan.html
@@ -335,6 +335,9 @@
             </div>
           <div id="upload_selection" class="middlecolumn" >
               <label>{% trans "Upload a District Index file:" %}</label>
+              <br><br>
+              <p style="font-weight: 1;">Upload a District Index File here to load a map template into your account. <a href="http://www.publicmapping.org/user-guide/user-guide-verison-1-2/managing-plans-1-2#TOC-Upload-Plan">What's a District Index File?</a></p>
+              <br>
               <form method="POST" enctype="multipart/form-data" action="/districtmapping/plan/upload/" id="frmUpload">
                 {% csrf_token %}
                 <input type="file" id="indexFile" name="indexFile"/>

--- a/django/publicmapping/redistricting/templates/viewplan.html
+++ b/django/publicmapping/redistricting/templates/viewplan.html
@@ -246,8 +246,8 @@
       ATTRIBUTION NOTICE SECTION ENDS
       {% endcomment %}
       <ul id="steps_tabs"> <!-- tabs have to be first UL in #steps or else tabs wont work -->
-        <li id="tab_plan"><a href="#step_plan">{% trans "Plan" %}</a><li>
-        <li id="tab_draw"><a href="#step_draw">{% if is_registered %}{% trans "Draw" %}{% else %}{% trans "View" %}{% endif %}</a></li>
+        <li id="tab_plan"><a href="#step_plan">Select</a><li>
+        <li id="tab_draw"><a href="#step_draw">Map</a></li>
         <li id="tab_evaluate"><a href="#step_evaluate">{% trans "Evaluate" %}</a></li>
         <li id="tab_share" class="{% if not is_registered %}ui-state-disabled{% endif %}"><a href="#step_share">Submit</a></li>
         {% if has_leaderboard and not plan.is_community %}


### PR DESCRIPTION
## Overview

Change header text and add sentence to explain upload map.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

 * Log in and ensure that the buttons on the header are `Select > Map > Evaluate > Submit` instead of `Map > Draw > Evaluate > Submit`
 * On the `Select` page, go to `Upload Map` and ensure that there are two sentence, the second with a link as specified on the story.

Closes [#159536735](https://www.pivotaltracker.com/story/show/159536735) and [#159309223](https://www.pivotaltracker.com/story/show/159309223)
