### PR TITLE
Changes from investigating AppServer deployment failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,19 +24,23 @@ before_deploy:
   -in district-builder-pa.pem.enc -out ~/.ssh/district-builder-pa.pem -d
 - cp django/publicmapping/config/config.xml deployment/user-data/config.xml
 - mv ./data/districtbuilder_data.zip deployment/user-data/
+- set -v
 deploy:
 - provider: script
   skip_cleanup: true
-  script: scripts/deploy
+  script: scripts/deploy | tee deployment.log
   on:
     repo: azavea/district-builder-dtl-pa
     branch: master
 - provider: script
   skip_cleanup: true
-  script: scripts/deploy
+  script: scripts/deploy | tee deployment.log
   on:
     repo: azavea/district-builder-dtl-pa
     branch: develop
 after_deploy:
-- git clean -fdx
+# Potential fix for truncated build logs.
+# https://github.com/travis-ci/travis-ci/issues/8973
+- cat deployment.log && sleep 10
+- docker-compose -f docker-compose.ci.yml run --rm --entrypoint git terraform clean -fdx
 - rm -f ~/.ssh/district-builder-pa.pem

--- a/scripts/infra
+++ b/scripts/infra
@@ -20,19 +20,20 @@ Execute Terraform subcommands with remote state management.
 "
 }
 
-function test_docker_endpoint () {
-  curl -is "https://${DOCKER_HOST}/info" \
-    --cert "${HOME}/.docker/cert.pem" \
-    --key "${HOME}/.docker/key.pem" \
-    --cacert "${HOME}/.docker/ca.pem" | grep "200 OK"
-}
-
 function wait_for_docker() {
 
-  while ! test_docker_endpoint;
-  do
-    test_docker_endpoint
+  for i in {1..5}; do
+      if docker-compose ps > /dev/null; then
+        echo 'Docker daemon is running!'
+        return
+      else
+        echo "Docker daemon is not running. $(( 5 - i)) attempts remaining."
+        sleep 5
+      fi;
   done
+
+  echo 'Error waiting for Docker daemon.'
+  exit 1
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then


### PR DESCRIPTION
## Overview

Add some `.travis.yml` changes that came about as I was working on #76. These changes largely serve to increase build output and logging, and to make sure that the build itself won't run forever. 

### Changes
- I put a hard limit on the number of times we'd check to see if the docker daemon is running
- Replaced the `curl` check with one based on `docker-compose`. 
- Use a fix suggested in https://github.com/travis-ci/travis-ci/issues/8973 to ensure that deployment logs are captured in console output.

### Checklist

- [x ] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Files changed in the PR have been `yapf`-ed for style violations~

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions
 * `develop` and  https://travis-ci.org/azavea/district-builder-dtl-pa/builds/419321778 was deployed to staging
 * No tests are necessary, just make sure travis build completes.

Connects #76
