### PR TITLE
Don't display submissions on the Leaderboard

### DIFF
--- a/django/publicmapping/redistricting/views.py
+++ b/django/publicmapping/redistricting/views.py
@@ -2111,6 +2111,8 @@ def submit_plan(request, planid):
         old_plan = Plan.objects.get(pk=planid)
         plan.id = None
         plan.owner = admin
+        # This is in fact not true, but prevents the plan from showing up on the Leaderboard
+        plan.is_valid = False
         plan.is_shared = False
         plan.version = 0
         # Plan names need to be unique by owner, so we have to add a random key


### PR DESCRIPTION
## Overview

Submissions were showing up in the Leadboard because all plans where `is_valid` is `True` show up there. This sets that value to `False` for submitted plans (which are copied from valid plans).

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

 * Create a valid Plan
 * Validate and submit it
 * Verify that the plan you are submitting itself shows up on the Leaderboard but that a plan with a name similar to `Submission by: username 0.5830290` does not (repeat these steps on `develop` or staging if you want to see this happen).

Closes #159431140
