### PR TITLE
Move Reference Layer info to lower left status bar

### DIFF
--- a/django/publicmapping/redistricting/templates/viewplan.html
+++ b/django/publicmapping/redistricting/templates/viewplan.html
@@ -546,10 +546,6 @@
               <label>Basemap</label>
               <div id="map_type_content_container" style="display: inline-block;"></div>
             </div>
-            <div id="reference_layer_id" class="layer_type_container">
-                <div id="reference_layer_label">{% trans "Reference Layer:" %}</div>
-                <div id="reference_layer_name">{% trans "None" %}</div>
-            </div>
           </div>
           {% block multi_member %}
           {% comment %}
@@ -870,6 +866,10 @@
        </div>
      </div>
      {% endif %}
+      <div id="reference_layer_id" class="toolset_group">
+        <label>{% trans "Reference Layer:" %}</label>
+          <span id="reference_layer_name">{% trans "None" %}</span>
+      </div>
      {% if plan and is_editable %}
      {% comment %}
 

--- a/django/publicmapping/static/css/core.css
+++ b/django/publicmapping/static/css/core.css
@@ -1531,7 +1531,7 @@ div#map_settings_content #map_settings_layers, div#map_settings_content .layer_t
     font-weight:500;
     vertical-align:middle;
     }
-div#map_settings_content #reference_layer_id   {display:none;margin: 4px 0 2px;float:left;line-height: 14px;display: none !important;}
+div#map_settings_content #reference_layer_id   {margin: 4px 0 2px;float:left;line-height: 14px;}
 div#map_settings_content #reference_layer_name  {
   font-weight: normal;
 }


### PR DESCRIPTION
## Overview

Moves the hidden Reference Layer status line from the basemap control, on the upper right of the map, down to the status bar, on the lower left of the map. Also unhides it.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

<img width="544" alt="screen shot 2018-08-24 at 4 28 42 pm" src="https://user-images.githubusercontent.com/447977/44584677-cb37fd80-a7ba-11e8-88e0-5feb60c8440b.png">

## Testing Instructions

 * View a map, confirm that the Reference Layer displays "County Lines" upon initial map load.
 * Change the reference layer to Census Tracts and None, and confirm that the reference layer display in the status bar behaves as you expect.

Closes #159991025
