### PR TITLE
Remove Assign to District white color

### DIFF
--- a/django/publicmapping/static/css/core.css
+++ b/django/publicmapping/static/css/core.css
@@ -1192,7 +1192,6 @@ div.toolset_group .help{
 div.toolset_group label {
   font-size: 11px;
   font-weight: 500;
-  color: #fff;
 }
 div.toolset_group select {
   width: 100px;

--- a/django/publicmapping/static/css/core.css
+++ b/django/publicmapping/static/css/core.css
@@ -1192,6 +1192,7 @@ div.toolset_group .help{
 div.toolset_group label {
   font-size: 11px;
   font-weight: 500;
+  color: #000000;
 }
 div.toolset_group select {
   width: 100px;


### PR DESCRIPTION
## Overview

Assign to District is explicitly set to white and disappears against the new background. I missed this in my feedback to Jeff, so I'm making the change myself. 

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

### Demo

Tested this in the browser by removing the `color:` line in CSS:

![image](https://user-images.githubusercontent.com/14098314/45194915-25a57500-b223-11e8-9b19-989de1737e8a.png)

### Notes

Just a trivial CSS change. Don't know if there's a best practice to remove the `color` element or explicitly set it to black, but feel free to let me know in the comments.

## Testing Instructions

 * Log in and load up a map
 * Assign to District should be visible as black against white background
