### PR TITLE
Require map to be re-validated after a change #160000139

### DIFF
--- a/django/publicmapping/static/js/statisticssets.js
+++ b/django/publicmapping/static/js/statisticssets.js
@@ -178,6 +178,11 @@ statisticssets = function(options) {
                 $('#map').trigger('resort_by_visibility');
                 $('#map').trigger('draw_highlighted_districts', [ true ]);
                 _displayCache[displayId] = rsp;
+                // Map has changed so require it to be re-validated
+                $('#verifiedp').addClass('hiddenelem');
+                $('#btnVerifyAndSubmit').removeClass('hiddenelem');
+                $('#submittocontest').addClass('inactivebox');
+                $('#btnEmailPlan').addClass('hiddenelem');
             }
         );  
     }


### PR DESCRIPTION
## Overview

Require map to be re-validated after a change

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- ~~[ ] Files changed in the PR have been `yapf`-ed for style violations~~

## Testing Instructions

* Make a valid map (or use https://github.com/azavea/district-builder-dtl-pa/files/2328961/testnew.zip if you need it)
* Reassign a geounit to render the map invalid
* Go to "Submit" tab and observe that the map must be re-validated to submit and form elements are properly disabled/greyed out.
* Click validate and observe the error
* Go back to map and reassign the geounit to its original district (the "Undo" feature doesn't seem to actually do this, which you'll notice if you refresh the page and see that your undone change has been redone...)
* Validate again and you should then be able to submit  

Closes #160000139
