### PR TITLE
Fix typo in Age 65+ field name

### DIFF
--- a/django/publicmapping/config/config.xml
+++ b/django/publicmapping/config/config.xml
@@ -73,7 +73,7 @@
                  short_name="35-49" displayed="false" sortkey="26" />
         <Subject id="age5064" field="A50_64_POP" name="Age - 50-64"
                  short_name="50-64" displayed="false" sortkey="27" />
-        <Subject id="age65o" field="A65O_POP" name="Age - 65 and over"
+        <Subject id="age65o" field="A650_POP" name="Age - 65 and over"
                  short_name="65+" displayed="false" sortkey="28" />
     </Subjects>
 


### PR DESCRIPTION
## Overview

Fixes https://www.pivotaltracker.com/story/show/160431658

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- ~~[ ] Files changed in the PR have been `yapf`-ed for style violations~~

## Testing Instructions

Run `./scripts/configure_pa_data`, create a new user and log in, and then follow steps to reproduce in bug ticket.