### PR TITLE
Change password reset workflow

### DIFF
--- a/django/publicmapping/publicmapping/templates/forgottenpassword.email
+++ b/django/publicmapping/publicmapping/templates/forgottenpassword.email
@@ -11,10 +11,12 @@ Context:
 {% autoescape off %}
 {% trans "Hello" %} {{ user.username }},
 
-{% trans "You requested a new password for the Public Mapping Project. Sorry for the inconvenience!  This is your new password" %}: {{ new_password }}
+You requested a new password for DistrictBuilder. Sorry for the inconvenience! This is your new password: {{ new_password }}
 
-{% trans "Thank you for using the Public Mapping Project." %}
+If you’d like to change it, go into My Account once you log on (top right corner) and create your new password. 
 
-{% trans "Happy Redistricting!" %}
-{% trans "The Draw the Lines Team" %}
+Thank you for participating in Draw the Lines PA.
+
+Happy Redistricting!
+The DTL Team
 {% endautoescape %}

--- a/django/publicmapping/publicmapping/templates/index.html
+++ b/django/publicmapping/publicmapping/templates/index.html
@@ -216,12 +216,12 @@
     </div>
     {% include "account.html" %}
     <div id="forgotpass">
-        <form id="forgotForm" action="/accounts/forgot/" method="POST">
+        <form id="forgotForm" action="/accounts/hint/" method="POST">
             {% csrf_token %}
             <div id="forgotprompt">
                 <div id="username_hint">{% trans "Get A Hint" %}</div>
                 <div>
-                    {% trans "Enter your username to retrieve your password hint that you used when registering for an account." %}
+                    Enter your username and email address to get your password hint.
                 </div>
                 <p>&nbsp;</p>
                 <table class="forgotTable">
@@ -230,13 +230,6 @@
                         <td><input id="forgotusername" name="forgotusername" class="field" maxlength="30"/></td>
                     </tr>
                 </table>
-                <div id="or">{% trans "OR" %}</div>
-
-                <div id="email_reset">{% trans "Reset Your Password" %}</div>
-                <div>
-                    {% trans "Enter your email address to reset your password if you have forgotten your username." %}
-                </div>
-                <p>&nbsp;</p>
                 <table class="forgotTable">
                     <tr>
                         <td class="fname">{% trans "Email" %}</td>
@@ -245,7 +238,7 @@
                 </table>
             </div>
             <div id="forgotButton">
-                <button id="doRemind">{% trans "Begin" %}</button>
+                <button id="doRemind">{% trans "Get Hint" %}</button>
             </div>
 
             <div id="forgothint">
@@ -254,7 +247,7 @@
 
                 <input id="forgothintbox" name="forgothintbox" class="field"/>
 
-                <p>{% trans "If you still can't recall your password, click on the 'Back' button, and enter your email address, so we can email your password to you." %}</p>
+                <p>{% trans "If you still can't recall your password, click on the 'Reset Password' button so we can reset and email your password to you." %}</p>
 
             </div>
             <div id="forgotsent">
@@ -262,7 +255,7 @@
                 <p>{% trans "Your password has been emailed to you. You should receive your password in your inbox in the next few minutes." %}</p>
             </div>
             <div id="forgotButton2">
-                <button id="doBack">{% trans "Back" %}</button>
+                <button id="doReset">{% trans "Reset Password" %}</button>
                 <button id="doClose">{% trans "Close" %}</button>
             </div>
         </form>

--- a/django/publicmapping/publicmapping/urls.py
+++ b/django/publicmapping/publicmapping/urls.py
@@ -43,6 +43,7 @@ urlpatterns = ([
         'template_name': 'index.html'
     }),
     url(r'^accounts/logout/$', publicmapping_views.userlogout),
+    url(r'^accounts/hint/$', publicmapping_views.passwordhint),
     url(r'^accounts/forgot/$', publicmapping_views.forgotpassword),
     url(r'^accounts/update/$', publicmapping_views.userupdate),
     url(r'^districtmapping/', include(redistricting_urls)),

--- a/django/publicmapping/static/js/register.js
+++ b/django/publicmapping/static/js/register.js
@@ -254,15 +254,10 @@ $(function(){
                 remindBtn.attr('disabled',null);
                 remindBtn.html('<span class="ui-button-text">'+btnText+'</span>');
                 if (data.success) {
-
                     if (data.mode == 'hinting') {
                         $('#forgotprompt, #forgotButton').css('display','none');
                         $('#forgothint, #forgotButton2').css('display','block');
                         $('#forgothintbox').val( data.hint );
-                    }
-                    else if (data.mode == 'sending') {
-                        $('#forgotprompt, #forgotButton').css('display','none');
-                        $('#forgotsent, #forgotButton2').css('display','block');
                     }
                 }
                 else if (data.field) {
@@ -272,14 +267,15 @@ $(function(){
                     if (data.field != 'username') {
                         $('#forgotemail').addClass('error');
                     }
+                } else {
+                    $('#forgotusername').val('');
+                    $('#forgotemail').val('');
                 }
             },
             error:function(xhr,textStatus,error){
                 var remindBtn = $('#doRemind');
                 remindBtn.html('<span class="ui-button-text">'+btnText+'</span>');
                 remindBtn.attr('disabled',true);
-            },
-            complete:function(xhr, textStatus){
                 $('#forgotusername').val('');
                 $('#forgotemail').val('');
             }
@@ -288,18 +284,62 @@ $(function(){
         return false;
     });
 
-    // do this operation when a user goes 'back' in the dialog
-    $('#doBack').click(function(){
-        $('#forgotprompt, #forgotButton').css('display','block');
-        $('#forgothint, #forgotsent, #forgotButton2').css('display','none');
+    // do this operation when a user clicks 'Reset Password' in the dialog
+    $('#doReset').click(function(){
+        var frm = $('#forgotForm')[0];
+        $('#forgotusername, #forgotemail').removeClass('error');
+
+        var resetBtn = $('#doReset');
+        resetBtn.attr('disabled',true);
+        var btnText = resetBtn.text();
+        resetBtn.html('<span class="ui-button-text" />').text(gettext('Please Wait...'));
+
+        $.ajax({
+            context:frm,
+            data: {
+                username: $('#forgotusername').val(),
+                email: $('#forgotemail').val(),
+                csrfmiddlewaretoken: $('input[name=csrfmiddlewaretoken]').val()
+            },
+            dataType:'json',
+            type:'POST',
+            url:'/accounts/forgot/',
+            success: function(data,textStatus,xhr){
+                var resetBtn = $('#doReset');
+                resetBtn.attr('disabled',null);
+                resetBtn.html('<span class="ui-button-text">'+btnText+'</span>');
+                if (data.success) {
+
+                    if (data.mode == 'sending') {
+                        $('#forgotprompt, #forgotButton').css('display','none');
+                        $('#forgothint, #forgotButton2').css('display','none');
+                        $('#forgotsent, #forgotButton2').css('display','block');
+                        $('#doReset').css('display','none');
+                    }
+                }
+            },
+            error:function(xhr,textStatus,error){
+                var resetBtn = $('#doReset');
+                resetBtn.html('<span class="ui-button-text">'+btnText+'</span>');
+                resetBtn.attr('disabled',true);
+            },
+            complete:function(xhr,textStatus){                
+                $('#forgotusername').val('');
+                $('#forgotemail').val('');
+            }
+        });
+
         return false;
     });
 
     // do this operation when a user closes the dialog
     $('#doClose').click(function(){
+        $('#forgotusername').val('');
+        $('#forgotemail').val('');
         $('#forgotpass').dialog('close');
         $('#forgotprompt, #forgotButton').css('display','block');
         $('#forgothint, #forgotsent, #forgotButton2').css('display','none');
+        $('#doReset').css('display','inline-block');
         return false;
     });
 


### PR DESCRIPTION
## Overview

This PR changes the password reset workflow to ensure that a password is only reset when both username and email are provided. 

With the new workflow, the user needs to enter both username and email to get a hint. Then, the user can either close the popup or opt to receive a new password sent to them.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

<img width="1680" alt="screen shot 2018-09-13 at 5 37 35 pm" src="https://user-images.githubusercontent.com/3959096/45517371-f095a700-b77b-11e8-97e3-ededeaf7c468.png">

<img width="1680" alt="screen shot 2018-09-13 at 5 37 39 pm" src="https://user-images.githubusercontent.com/3959096/45517377-f4292e00-b77b-11e8-8747-b8748fe4cf90.png">

<img width="1680" alt="screen shot 2018-09-13 at 5 37 43 pm" src="https://user-images.githubusercontent.com/3959096/45517378-f68b8800-b77b-11e8-8142-6ac0ed08371b.png">


## Testing Instructions

 * Click "Forgot Password"
 * Test to see that you need a correct pair of both username and email to get a hint.
 * Test to see that on clicking "Reset Password" after getting the hint, the password is reset and an email is sent (or logged in the debugger).

Closes [#160316709](https://www.pivotaltracker.com/story/show/160316709)
