### PR TITLE
Add cronjob to remove old images from App Server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,23 +26,19 @@ before_deploy:
   -in district-builder-pa.pem.enc -out ~/.ssh/district-builder-pa.pem -d
 - cp django/publicmapping/config/config.xml deployment/user-data/config.xml
 - mv ./data/districtbuilder_data.zip deployment/user-data/
-- set -v
 deploy:
 - provider: script
   skip_cleanup: true
-  script: DB_SETTINGS_BUCKET=${PROD_DB_SETTINGS_BUCKET} DB_DOCKER_HOST=${PROD_DB_DOCKER_HOST} scripts/deploy | tee deployment.log
+  script: DB_SETTINGS_BUCKET=${PROD_DB_SETTINGS_BUCKET} DB_DOCKER_HOST=${PROD_DB_DOCKER_HOST} scripts/deploy
   on:
     repo: azavea/district-builder-dtl-pa
     branch: master
 - provider: script
   skip_cleanup: true
-  script: scripts/deploy | tee deployment.log
+  script: scripts/deploy
   on:
     repo: azavea/district-builder-dtl-pa
     branch: develop
 after_deploy:
-# Potential fix for truncated build logs.
-# https://github.com/travis-ci/travis-ci/issues/8973
-- cat deployment.log && sleep 10
 - docker-compose -f docker-compose.ci.yml run --rm --entrypoint git terraform clean -fdx
 - rm -f ~/.ssh/district-builder-pa.pem

--- a/deployment/terraform/templates/cloud-config.tpl
+++ b/deployment/terraform/templates/cloud-config.tpl
@@ -7,6 +7,17 @@ users:
 packages:
   - aws-cli
   - unzip
+  - vim
+
+write_files:
+- owner: root:root
+  path: /etc/cron.d/docker-prune
+  content: |
+    # Remove all images older than 7 days (168 hours)
+    @daily root docker system prune -af --filter "until=168h"
+
+bootcmd:
+  - mv /etc/init/ecs.conf /etc/init/ecs.conf.disabled
 
 runcmd:
   - curl -L https://github.com/docker/compose/releases/download/1.21.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose


### PR DESCRIPTION
## Overview

Sets up a cronjob that runs `docker system prune`  daily on the app server. This should help speed up builds on the app server, and keep Travis from timing out. 

### Changes
- Update cloud-init script to write out `/etc/cron.d/docker-prune`, which prunes docker images daily
- Install `vim` on the app server, which has no text editor at all
- Stop the ECS service, and disable upstart service by commenting out the `start on` configuration parameter.
- Undo the work in #77 that turns up travis logging. It's no longer necessary, and is actually so verbose that deployments are not visible in the travis console logs.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Files changed in the PR have been `yapf`-ed for style violations~

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * See travis builds:
    - https://travis-ci.org/azavea/district-builder-dtl-pa/builds/428312569
    - https://travis-ci.org/azavea/district-builder-dtl-pa/builds/428351521
 * SSH into Staging App server. Verify that crontab exists and that ECS isn't running.
```bash
$ ssh -A -l ec2-user bastion.staging.pa.districtbuilder.azavea.com

# SSH into App server
$ ssh pa.districtbuilder.internal
[ec2-user@ip-10-0-0-179 ~]$ sudo status ecs
ecs stop/waiting
[ec2-user@ip-10-0-0-179 ~]$ sudo status ecs^C
[ec2-user@ip-10-0-0-179 ~]$ sudo cat /etc/cron.d/docker-prune 
@daily root docker system prune -af --filter "until=168h"
[ec2-user@ip-10-0-0-179 ~]$ sudo vim test.txt
```
Closes #76
