### PR TITLE
Add share buttons to successful submit popup

### DIFF
--- a/django/publicmapping/publicmapping/templates/index.html
+++ b/django/publicmapping/publicmapping/templates/index.html
@@ -138,8 +138,7 @@
         <ul class="share-buttons">
           <li class="twitter-tweet">
             <a href="https://twitter.com/intent/tweet"
-              data-text="{% trans 'Homepage tweet text' %}"
-              data-hashtags="redistricting"
+              data-text="I'm drawing a voting map for Draw the Lines PA. Join me! @drawthelinespa #SlaytheGerrymander"
               class="twitter-share-button">
               {% trans "Tweet" %}
             </a>
@@ -150,6 +149,7 @@
             <div
               class="fb-share-button"
               data-href="{{ request.build_absolute_uri }}"
+              data-text="I'm drawing a voting map for Draw the Lines PA. Join me! @drawthelinespa #SlaytheGerrymander"
               data-layout="button_count"
               data-size="small"
               data-mobile-iframe="true">
@@ -167,7 +167,7 @@
           </li>
 
           <script type="text/javascript">
-            var mailLink = 'mailto:?subject={% trans "Welcome to DistrictBuilder" %}&body=' + window.location.href;
+            var mailLink = 'mailto:?subject=I%27m%20drawing%20a%20voting%20map%20for%20Draw%20the%20Lines%20PA.%20Join%20me!%20%40drawthelinespa%20%23SlaytheGerrymander&body=' + window.location.href;
             document.getElementById('email-share-link').setAttribute('href', mailLink);
           </script>
         </ul>

--- a/django/publicmapping/redistricting/templates/editplan.html
+++ b/django/publicmapping/redistricting/templates/editplan.html
@@ -507,6 +507,40 @@
             </tr>
         </table>
         <div id="email_plan_required_note"> * {% trans "Indicates required field" %} </div>
+        <div style="display:none">
+        <ul class="share-buttons" id="submit-share-buttons">
+          <li class="twitter-tweet">
+            <a href="https://twitter.com/intent/tweet"
+              data-text="I just submitted a voting map to the Draw the Lines PA mapping competition. Join me! @drawthelinespa #SlaytheGerrymander."
+              data-url="https://map.drawthelinespa.org/"
+              class="twitter-share-button">
+              {% trans "Tweet" %}
+            </a>
+            <script type="text/javascript" src="https://platform.twitter.com/widgets.js"></script>
+          </li>
+
+          <li class="facebook-like">
+            <div
+              class="fb-share-button"
+              data-href="https://map.drawthelinespa.org/"
+              data-text="I just submitted a voting map to the Draw the Lines PA mapping competition. Join me! @drawthelinespa #SlaytheGerrymander."
+              data-layout="button_count"
+              data-size="small"
+              data-mobile-iframe="true">
+                <a target="_blank"
+                  href="https://www.facebook.com/sharer/sharer.php?u=https://map.drawthelinespa.org/&amp;src=sdkpreparse"
+                  class="fb-xfbml-parse-ignore">{% trans "Share" %}
+                </a>
+            </div>
+          </li>
+
+          <li class="email-share">
+            <a id="email-share-link" href="mailto:?subject=I%20just%20submitted%20a%20voting%20map%20to%20the%20Draw%20the%20Lines%20PA%20mapping%20competition.%20Join%20me!%20%40drawthelinespa%20%23SlaytheGerrymander&body=https://map.drawthelinespa.org/">
+              <button id="email-share-button"><img id="email-share-img" src="{% static 'images/icon-mail.png' %}"></button>
+            </a>
+          </li>
+        </ul>
+        </div>
     </div>
     <script type="text/javascript" src="{% static 'js/emailplan.js' %}"></script>
     <script type="text/javascript">

--- a/django/publicmapping/static/js/emailplan.js
+++ b/django/publicmapping/static/js/emailplan.js
@@ -122,6 +122,8 @@ emailplan = function(options) {
             escapeOnClose: false, resizable:false,
             open: function() { $(".ui-dialog-titlebar-close", $(this).parent()).hide(); }
         });
+
+        var shareButtons = $('#submit-share-buttons');
         
         $.ajax({
             type: 'POST',
@@ -131,13 +133,13 @@ emailplan = function(options) {
                 waitDialog.remove();
                 if (data.success) {
                     $('<div />').attr('title', gettext('Submitting Plan'))
-                        .text(gettext('Thanks, your plan has been submitted.')).dialog({
+                        .text(gettext('Success! Map submitted. Share Draw the Lines with your friends:')).dialog({
                           modal:true, resizable:false,
                           buttons: [{
                             text: gettext("OK"),
                             click: function() { $(this).dialog('close'); }
                           }]
-                      });
+                      }).append(shareButtons);
                 } else if ('redirect' in data) {
                     window.location.href = data.redirect;
                 } else if ('message' in data) {


### PR DESCRIPTION
## Overview

Add share buttons to successful submit popup and change share text. 

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Files changed in the PR have been `yapf`-ed for style violations~

### Demo

<img width="412" alt="screen shot 2018-09-14 at 12 30 38 pm" src="https://user-images.githubusercontent.com/3959096/45563091-47ea5480-b81a-11e8-9d87-d943635e76ad.png">


## Testing Instructions

 * Validate and submit a plan
 * Verify that the successful submit popup has share buttons
 * Confirm text changes to popup and to share buttons (Tweet and Email are good examples)

Closes [#159998819](https://www.pivotaltracker.com/story/show/159998819)
