### PR TITLE
Avoid large contiguity overrides query if none exist

### DIFF
--- a/django/publicmapping/redistricting/models.py
+++ b/django/publicmapping/redistricting/models.py
@@ -3235,7 +3235,7 @@ class District(models.Model):
         objects whose two referenced geounits both fall within
         the geometry of this district.
         """
-        if not self.geom:
+        if not self.geom or ContiguityOverride.objects.count() == 0:
             return []
 
         filter = Q(override_geounit__geom__within=self.geom)


### PR DESCRIPTION
## Overview

The query for obtaining contiguity overrides is slow, because it is being passed in a large piece of WKB. This commit first checks to see if any contiguity overrides are defined before issuing the query.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

 * To see how massive the query was beforehand:
    * Don't checkout this branch yet
    * Enable DEBUG mode in Django
    * `vagrant ssh`
    * `docker-compose exec django ./manage.py shell_plus --print-sql`
    * `from redistricting.calculators import Contiguity; Contiguity().compute(plan=Plan.objects.all()[0])`
    * Watch as the WKB flows down your terminal
 * Do this again with this branch in place and notice a much more reasonable set of query output
 * Load up the UI and ensure that scores are still calculating correctly -- particularly the contiguity score, which is the only thing this code change affects