### PR TITLE
Make numbers in app more readable

### DIFF
--- a/django/publicmapping/redistricting/calculators.py
+++ b/django/publicmapping/redistricting/calculators.py
@@ -168,9 +168,9 @@ class CalculatorBase(object):
         @return: A string representing the result as a percentage
         """
         if span:
-            t = Template('<span>{{ percentage|floatformat:2 }}%</span>')
+            t = Template('<span>{{ percentage|floatformat:1 }}%</span>')
         else:
-            t = Template('{{ percentage|floatformat:2 }}%')
+            t = Template('{{ percentage|floatformat:1 }}%')
         c = Context({'percentage': self.result['value'] * 100})
         return t.render(c)
 
@@ -1434,9 +1434,11 @@ class Interval(CalculatorBase):
             if 'index' in self.result and 'subject' in self.result:
                 interval = self.result['index']
                 interval_class = "interval_%d" % interval if interval >= 0 else 'no_interval'
+                a = "{:,}".format(self.result['value'])
+                interval_text = a[:a.index('.')]
                 t = '<span class="{{ class }} {{ result.subject }}">' \
-                    '{{ result.value|floatformat:0 }}</span>'
-                c = {'class': interval_class}
+                    '{{ text }}</span>'
+                c = {'class': interval_class, 'text': interval_text}
                 return self.template(t, c)
         return self.empty_html_result
 

--- a/django/publicmapping/redistricting/tests/test_score_render.py
+++ b/django/publicmapping/redistricting/tests/test_score_render.py
@@ -59,8 +59,8 @@ class ScoreRenderTestCase(BaseTestCase):
             markup = panel.render([self.plan, self.plan2])
             expected = 'testPlan:<span>9</span>' + \
                 'testPlan2:<span>9</span>' + \
-                'testPlan:18.18%' + \
-                'testPlan2:10.64%'
+                'testPlan:18.2%' + \
+                'testPlan2:10.6%'
 
             self.assertEqual(expected, markup,
                              'The markup was incorrect. (e:"%s", a:"%s")' %
@@ -97,11 +97,11 @@ class ScoreRenderTestCase(BaseTestCase):
             template.close()
 
             markup = panel.render(districts)
-            expected = ('District 1:86.83%<img class="yes-contiguous" '
+            expected = ('District 1:86.8%<img class="yes-contiguous" '
                         'src="/static/images/icon-check.png">'
-                        'District 2:86.83%<img class="yes-contiguous" '
+                        'District 2:86.8%<img class="yes-contiguous" '
                         'src="/static/images/icon-check.png">'
-                        'Unassigned:0.00%<img class="yes-contiguous" '
+                        'Unassigned:0.0%<img class="yes-contiguous" '
                         'src="/static/images/icon-check.png">')
             self.assertEqual(
                 expected, markup,
@@ -149,8 +149,8 @@ class ScoreRenderTestCase(BaseTestCase):
 
         markup = display.render(plans)
 
-        expected = 'testPlan2:10.64%' + \
-            'testPlan:18.18%' + \
+        expected = 'testPlan2:10.6%' + \
+            'testPlan:18.2%' + \
             'testPlan:<span>9</span>' + \
             'testPlan2:<span>9</span>'
         self.assertEqual(expected, markup,
@@ -185,11 +185,11 @@ class ScoreRenderTestCase(BaseTestCase):
         template.close()
 
         markup = display.render(self.plan)
-        expected = ('District 1:86.83%<img class="yes-contiguous" '
+        expected = ('District 1:86.8%<img class="yes-contiguous" '
                     'src="/static/images/icon-check.png">'
-                    'District 2:86.83%<img class="yes-contiguous" '
+                    'District 2:86.8%<img class="yes-contiguous" '
                     'src="/static/images/icon-check.png">'
-                    'Unassigned:0.00%<img class="yes-contiguous" '
+                    'Unassigned:0.0%<img class="yes-contiguous" '
                     'src="/static/images/icon-check.png">')
         self.assertEqual(expected, markup,
                          'The markup was incorrect. (e:"%s", a:"%s")' %
@@ -199,11 +199,11 @@ class ScoreRenderTestCase(BaseTestCase):
             self.plan.get_districts_at_version(
                 self.plan.version, include_geom=False))
 
-        expected = ('District 1:86.83%<img class="yes-contiguous" '
+        expected = ('District 1:86.8%<img class="yes-contiguous" '
                     'src="/static/images/icon-check.png">'
-                    'District 2:86.83%<img class="yes-contiguous" '
+                    'District 2:86.8%<img class="yes-contiguous" '
                     'src="/static/images/icon-check.png">'
-                    'Unassigned:0.00%<img class="yes-contiguous" '
+                    'Unassigned:0.0%<img class="yes-contiguous" '
                     'src="/static/images/icon-check.png">')
         self.assertEqual(expected, markup,
                          'The markup was incorrect. (e:"%s", a:"%s")' %

--- a/django/publicmapping/redistricting/tests/test_scoring.py
+++ b/django/publicmapping/redistricting/tests/test_scoring.py
@@ -118,7 +118,7 @@ class ScoringTestCase(BaseTestCase):
         # HTML
         score = schwartzFunction.score(self.district1, 'html')
         self.assertEqual(
-            "86.83%", score,
+            "86.8%", score,
             'Schwartzberg HTML for District 1 was incorrect: ' + score)
 
         # JSON

--- a/django/publicmapping/static/js/mapping.js
+++ b/django/publicmapping/static/js/mapping.js
@@ -2432,7 +2432,7 @@ function mapinit(srs,maxExtent) {
 
                 newRuleTitle = rule.title.indexOf('.') === -1 ? rule.title :
                     rule.title.substring(0, rule.title.indexOf('.'))
-                title.append( numberWithCommas(newRuleTitle) );
+                title.append(numberWithCommas(newRuleTitle));
 
                 row.append(title);
 

--- a/django/publicmapping/static/js/mapping.js
+++ b/django/publicmapping/static/js/mapping.js
@@ -2425,7 +2425,14 @@ function mapinit(srs,maxExtent) {
                 row.append(swatch);
 
                 var title = $('<td/>');
-                title.append( rule.title );
+
+                var numberWithCommas = function(x) {
+                  return x.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+                }
+
+                newRuleTitle = rule.title.indexOf('.') === -1 ? rule.title :
+                    rule.title.substring(0, rule.title.indexOf('.'))
+                title.append( numberWithCommas(newRuleTitle) );
 
                 row.append(title);
 


### PR DESCRIPTION
## Overview

Make population and percentages numbers more readable. 
 - Reduce all percentage stats to 1 decimal place
 - Add commas to all population numbers
 - Drop the decimal from the populations in the map legend

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Check that all populations on the stats panel have commas. Check to see this is true with big numbers and small numbers.
 * Check the map legend to see that the populations have commas but no decimals.
 * Check that all percentages on the stats panel have only 1 decimal place. 

Closes [#160602296](https://www.pivotaltracker.com/story/show/160602296)