### PR TITLE
Override gunicorn command in production

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -25,6 +25,16 @@ services:
       - /opt/district-builder/user-data/districtbuilder_data.zip:/data/districtbuilder_data.zip
       - /opt/district-builder/user-data/config_settings.py:/usr/src/app/publicmapping/config_settings.py
       - /opt/district-builder/user-data/config.xml:/usr/src/app/config/config.xml
+    command:
+      - "--workers=2"
+      - "--timeout=60"
+      - "--bind=0.0.0.0:${WEB_APP_PORT}"
+      - "--log-level=info"
+      - "--access-logfile=-"
+      - "--error-logfile=-"
+      - "--timeout=300"
+      - "-kgevent"
+      - "publicmapping.wsgi"
     logging:
       driver: syslog
       options:


### PR DESCRIPTION
## Overview

Override the gunicorn command arguments in `docker-compose.production.yml` to disable `--reload` and make `--log-level=INFO` in built container images.

Fixes #100 

## Notes

My thinking in adding an override to `docker-compose.production.yml` was because of this preexisting mechanism:

https://github.com/azavea/district-builder-dtl-pa/blob/70ff4f1abca514289be4bb9a3b942c97beaaf3d1/scripts/update#L64-L68

## Testing Instructions

First, setup your environment for DistrictBuilder DTL staging:

```bash
$ export AWS_PROFILE=district-builder-pa
$ export DB_SETTINGS_BUCKET=district-builder-dtl-staging-config-us-east-1
```

Download Docker client certificates from S3 and unzip:

```bash
$ aws s3 cp s3://${DB_SETTINGS_BUCKET}/docker_certs/client/client.zip ./client.zip
$ unzip ./client.zip -d client
```

Configure remote Docker host:

```bash
$ export DOCKER_HOST=origin.staging.pa.districtbuilder.azavea.com:2476
$ export DOCKER_TLS_VERIFY=1
$ export DOCKER_CERT_PATH=./client
```

Configure Docker Compose for production:

```bash
$ cp .env.sample .env
$ export COMPOSE_FILE=docker-compose.yml:docker-compose.production.yml
$ export COMPOSE_PROJECT_NAME=districtbuilder
```

Before cycling changes, see old gunicorn command arguments:
```bash
$ docker-compose top | grep gunicorn
root   13200   13168   1    20:33   ?     00:00:00   /usr/local/bin/python /usr/local/bin/gunicorn --workers=2 --timeout=60 --bind=0.0.0.0:8080 --reload --log-level=debug --access-logfile=- --error logfile=- --timeout=300 -kgevent publicmapping.wsgi
root   13276   13200   13   20:33   ?     00:00:01   /usr/local/bin/python /usr/local/bin/gunicorn --workers=2 --timeout=60 --bind=0.0.0.0:8080 --reload --log-level=debug --access-logfile=- --error logfile=- --timeout=300 -kgevent publicmapping.wsgi
root   13277   13200   13   20:33   ?     00:00:01   /usr/local/bin/python /usr/local/bin/gunicorn --workers=2 --timeout=60 --bind=0.0.0.0:8080 --reload --log-level=debug --access-logfile=- --error logfile=- --timeout=300 -kgevent publicmapping.wsgi
```

Finally, cycle changes and verify:

```bash
$ export GIT_COMMIT=(git rev-parse --short HEAD)
$ docker-compose build django && docker-compose up -d django
$ docker-compose top | grep gunicorn
root   16068   16049   0   20:48   ?     00:00:00   /usr/local/bin/python /usr/local/bin/gunicorn --workers=2 --timeout=60 --bind=0.0.0.0:8080 --log-level=info --access-logfile=- --error-logfile=-
root   16148   16068   0   20:48   ?     00:00:01   /usr/local/bin/python /usr/local/bin/gunicorn --workers=2 --timeout=60 --bind=0.0.0.0:8080 --log-level=info --access-logfile=- --error-logfile=-
root   16150   16068   0   20:48   ?     00:00:01   /usr/local/bin/python /usr/local/bin/gunicorn --workers=2 --timeout=60 --bind=0.0.0.0:8080 --log-level=info --access-logfile=- --error-logfile=-
```


