### PR TITLE
Add CloudWatch logging configuration to App Server

### DIFF
--- a/deployment/terraform/compute.tf
+++ b/deployment/terraform/compute.tf
@@ -30,6 +30,8 @@ data "template_file" "user_data" {
 
   vars {
     zip_file_uri = "${var.remote_state_bucket_prefix}-${lower(var.environment)}-config-${var.aws_region}/docker_certs/server/${lower(var.state)}.zip"
+    state        = "${upper(var.state)}"
+    environment  = "${var.environment}"
   }
 }
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -34,5 +34,5 @@ variable "ssh_identity_file_path" {
 
 variable "cloudfront_aliases" {
   description = "List of CNAMES that will refer to this project"
-  default = []
+  default     = []
 }


### PR DESCRIPTION
## Overview

This PR updates adds a CloudWatch logs configuration to ship `dmesg`, `/var/log/messages` (which includes application logs) and `/var/log/docker` from the App Server to a CloudWatch logs group. This should help us troubleshoot outages in situations where we don't have access to the App Server.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Files changed in the PR have been `yapf`-ed for style violations~

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * See CloudWatch logs in the DTL [CloudWatch console](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logStream:group=logStagingPAAppServer). You should see logs from
    * `dmesg`
    * `/var/log/messages`
        * If you search `districtbuilder` within this stream, application logs should be visible
    * `/var/log/docker`
* Reboot the App Server from the console, then SSH in once it's back online. Make sure `awslogs` is running.
```bash
$ ssh ec2-user@bastion.staging.pa.districtbuilder.azavea.com
$ ssh pa.districtbuilder.internal
$ sudo chkconfig --list awslogs
awslogs        	0:off	1:off	2:on	3:on	4:on	5:on	6:off
```
Needs azavea/district-builder-core-deployment#11
Closes #96 
