### PR TITLE
Increase nginx buffer sizes

### DIFF
--- a/nginx/default.template
+++ b/nginx/default.template
@@ -15,9 +15,25 @@ server {
   # Long timeouts are necessary for extended split reports
   proxy_read_timeout 300s;
 
+  location ~ /districtmapping/plan/\d+/unlockedgeometries/ {
+    client_max_body_size 20m;
+    client_body_buffer_size 1m;
+
+    # More buffers are necessary for responses containing
+    # Polygon selections
+    proxy_buffers 24 4k;
+    proxy_pass http://web;
+  }
+
+  location ~ /districtmapping/plan/\d+/district/versioned/ {
+    # More buffers are necessary for responses containing
+    # Polygon selections
+    proxy_buffers 24 4k;
+    proxy_pass http://web;
+  }
+
   location / {
     proxy_pass http://web;
-    client_max_body_size 20M;
   }
 
   location /geoserver/ {


### PR DESCRIPTION
## Overview

Increase `client_body_buffer_size` and `proxy_buffers` so that nginx can handle requests/responses containing polygons with a large number of coordinates in memory. This should stop nginx from buffering requests to disk.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Files changed in the PR have been `yapf`-ed for style violations~

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes
- I allocated 1MB in buffer space because the largest request/response I was able to find in the logs or generate myself was ~700K.

- This change should keep us from buffering to disk in most cases, but since the there's no upper bound on the amount of coordinates included in a Polygon, we may still end up writing to disk if a user draws a big enough shape. The plan is to increase the buffer size now, and monitor the production web server's performance to see if further changes are necessary. 

## Testing Instructions

 * In one terminal window, run `scripts/update` to rebuild nginx, and `scripts/update` to start the app.
 * In another terminal window, run `docker-compose logs -f nginx | grep warn` so you can see if nginx is buffering any requests or responses to disk.
 * Visit the app at http://localhost:8080
 * Select a new plan to edit
 * Zoom in 4x
 * Using the Polygon select tool, slowly select a medium sized area on the map. Go slowly so that any small mouse movements are recorded. 
 * Add the selection to your plan
 * Repeat a few times (I did this 9x during my reproductions) so that you have a bunch of Districts that are represented by large Polygons.
 * Refresh the page (so that we invoke the `/district/versioned` endpoint)
 * Ensure that there are no buffer warnings in the Nginx logs

Closes #101 
