### PR TITLE
Add Django watchman health check to App Server

### DIFF
--- a/django/publicmapping/publicmapping/settings.py
+++ b/django/publicmapping/publicmapping/settings.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = [
     'polib',
     'rosetta',
     'tagging',
+    'watchman',
 
     # local
     'publicmapping',
@@ -249,6 +250,12 @@ WEB_TEMP = '/tmp'
 SITE_ID = 2
 
 REPORTS_ENABLED = 'CALC'
+
+# Watchman config
+WATCHMAN_CHECKS = (
+    'watchman.checks.caches',
+    'watchman.checks.databases',
+)
 
 # NOTE: Leave this at the end of the file!
 # These settings are generated based on config.xml

--- a/django/publicmapping/publicmapping/settings.py
+++ b/django/publicmapping/publicmapping/settings.py
@@ -222,6 +222,7 @@ KEY_VALUE_STORE = {
     'DB': os.getenv('KEY_VALUE_STORE_DB'),
 }
 
+MAP_SERVER_PORT = os.getenv('WEB_APP_PORT')
 MAP_SERVER = os.getenv('MAP_SERVER_HOST')
 MAP_SERVER_USER = os.getenv('MAP_SERVER_ADMIN_USER')
 MAP_SERVER_PASS = os.getenv('MAP_SERVER_ADMIN_PASSWORD')
@@ -255,7 +256,10 @@ REPORTS_ENABLED = 'CALC'
 WATCHMAN_CHECKS = (
     'watchman.checks.caches',
     'watchman.checks.databases',
+    'redistricting.health_checks.check_geoserver'
 )
+
+WATCHMAN_ERROR_CODE = 500
 
 # NOTE: Leave this at the end of the file!
 # These settings are generated based on config.xml

--- a/django/publicmapping/publicmapping/urls.py
+++ b/django/publicmapping/publicmapping/urls.py
@@ -32,6 +32,7 @@ js_info_dict = {
 
 urlpatterns = ([
     url(r'^$', publicmapping_views.index),
+    url(r'^health-check/', include('watchman.urls')),
     url(r'^i18n', include('django.conf.urls.i18n')),
     url(r'^rosetta', include('rosetta.urls')),
     url(r'^jsi18n$',

--- a/django/publicmapping/redistricting/config.py
+++ b/django/publicmapping/redistricting/config.py
@@ -1054,21 +1054,42 @@ class SpatialUtils:
         # provide a way to easily change it.
         admin_user = 'admin'
         admin_password = os.getenv('MAP_SERVER_ADMIN_PASSWORD')
-        user_pass = '%s:%s' % (admin_user, admin_password)
 
-        auth = 'Basic %s' % base64.b64encode(user_pass)
         self.headers = {
-            'default': {
-                'Authorization': auth,
-                'Content-Type': 'application/json',
-                'Accepts': 'application/json'
-            },
-            'sld': {
-                'Authorization': auth,
-                'Content-Type': 'application/vnd.ogc.sld+xml',
-                'Accepts': 'application/xml'
-            }
+            'default': self.create_auth_headers(admin_user,
+                                                admin_password,
+                                                'application/json',
+                                                'application/json'),
+            'sld': self.create_auth_headers(admin_user, admin_password,
+                                            'application/vnd.ogc.sld+xml',
+                                            'application/xml'),
         }
+
+    @staticmethod
+    def create_auth_headers(username, password,
+                            content_type=None,
+                            accepts=None):
+        """
+        Construct HTTP basic auth headers.
+
+        @param username (string)
+        @param password (string)
+        @param content_type (string, optional): Value for Content-Type header
+        @param accepts (string, optional): Value for Accepts header
+
+        @return: A dictionary of Basic Auth headers including:
+                - Authorization
+                - Content-Type
+                - Accepts
+        """
+        user_pass = '%s:%s' % (username, password)
+
+        headers = {'Authorization': 'Basic %s' % base64.b64encode(user_pass)}
+
+        # Add additional headers, if provided
+        headers.update({'Content-Type': content_type} if content_type else {})
+        headers.update({"Accepts": accepts} if accepts else {})
+        return headers
 
     def purge_geoserver(self):
         """

--- a/django/publicmapping/redistricting/health_checks.py
+++ b/django/publicmapping/redistricting/health_checks.py
@@ -1,0 +1,27 @@
+"""Geoserver health check."""
+
+import requests
+
+from config import SpatialUtils
+from django.conf import settings
+
+
+def check_geoserver():
+    """Check status of all geoserver services."""
+    auth_headers = SpatialUtils.create_auth_headers(
+        'admin',
+        settings.MAP_SERVER_PASS,
+        accepts='application/json')
+
+    geoserver_status_url = 'http://%s:%s/geoserver/rest/about/status.json' % (
+        settings.MAP_SERVER,
+        settings.MAP_SERVER_PORT)
+
+    geoserver_status = requests.get(
+        geoserver_status_url,
+        headers=auth_headers).json()['about']['status']
+
+    # Health check should fail if all services aren't available.
+    assert len(filter(lambda x: not x['isAvailable'],
+               geoserver_status)) == 0
+    return {'geoserver': {"ok": True}}

--- a/django/publicmapping/requirements.txt
+++ b/django/publicmapping/requirements.txt
@@ -30,3 +30,4 @@ python-dateutil==2.6.0
 requests==2.18.4
 rollbar==0.14.1
 git+git://github.com/PublicMapping/district-builder-config.git@0.1.0
+django-watchman==0.15.0

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -19,6 +19,11 @@ services:
       - ./django/publicmapping/static/:/opt/static/
 
   django:
+    healthcheck:
+      test: ["CMD-SHELL", "/usr/local/bin/python", "manage.py", "watchman"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
     volumes:
       - ./django/publicmapping/:/usr/src/app/
       - ./data/:/data/


### PR DESCRIPTION
## Overview

This PR adds a `/health-check/` endpoint to app servers so that we can detect when they're out of service. I added the endpoint and a `django-watchman` configuration that checks databases and caches.

### Checklist

- [ x ] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Files changed in the PR have been `yapf`-ed for style violations~

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Once this is merged, we'll still have to turn enable Production app monitoring using Panopta.


## Testing Instructions

 * Run `docker-compose up --no-deps -d  nginx django`
 * Do `curl http://localhost:8080/health-check/ `
 * Ensure that the service returns a 500 status code
 * Run `docker-compose up -d` to start all services
 * Do `curl http://localhost:8080/health-check/ `
 * Ensure that the endpoint returns a 200 status code.

Closes #105 
