### PR TITLE
Fix "Assign to District" text color

### DIFF
--- a/django/publicmapping/static/css/core.css
+++ b/django/publicmapping/static/css/core.css
@@ -1204,6 +1204,10 @@ background-color: transparent;
 border:none;
 }
 
+#control_assign_district > label {
+  color: #000;
+}
+
 div#no_edit_at_zoom_level {
   height: 51px;
   width: 70%;

--- a/django/publicmapping/static/css/core.css
+++ b/django/publicmapping/static/css/core.css
@@ -1192,7 +1192,7 @@ div.toolset_group .help{
 div.toolset_group label {
   font-size: 11px;
   font-weight: 500;
-  color: #000000;
+  color: #fff;
 }
 div.toolset_group select {
   width: 100px;


### PR DESCRIPTION
## Overview

A small issue was introduced when we made a change to turn the "Assign to District" text to black (was illegible -- white text on a white background) that made the text in the bottom left disappear (turned it black on a black background). This reverts that change and uses a different selector to change only the "Assign to District" text color.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- ~~[ ] Files changed in the PR have been `yapf`-ed for style violations~~

### Demo

**Before**
![dtl-text-color-bug-before](https://user-images.githubusercontent.com/2926237/47043666-29021980-d15c-11e8-93e0-6cf2e27cf1fe.png)

**After**
![dtl-text-color-bug-after](https://user-images.githubusercontent.com/2926237/47043672-2e5f6400-d15c-11e8-8a38-34b9ed002aeb.png)

## Testing Instructions

* Check out branch, log in, and go to the map page.
* Verify that "Assign to District" is black and text in bottom left is white