### PR TITLE
 Change base layer picker pill styling

### DIFF
--- a/django/publicmapping/static/css/core.css
+++ b/django/publicmapping/static/css/core.css
@@ -675,8 +675,8 @@ width: 100%;
 }
 
 label.ui-state-active {
-  background-color: #004FE2 !important;
-  color: #fff !important
+  background-color: #dbe9f3 !important;
+  color: #000 !important
 }
 
 div#form_action button {margin-top: 10px;width: 100%;background-color: #004FE2 !important;color: #fff !important;border-color: transparent !important;font-weight: 500;}


### PR DESCRIPTION
## Overview

Change base layer picker pill styling.

<img width="302" alt="screen shot 2018-10-24 at 4 33 35 pm" src="https://user-images.githubusercontent.com/3959096/47460293-1b780f80-d7ac-11e8-9ab1-1e68a5e3ab85.png">

## Testing Instructions

 * Verify that pill looks like what's above, where `Topo` is selected and `Road` is being hovered over

Closes [#161266050](https://www.pivotaltracker.com/story/show/161266050)
