### PR TITLE
Use centralized GeoServer image

### DIFF
--- a/geoserver/Dockerfile
+++ b/geoserver/Dockerfile
@@ -1,30 +1,4 @@
 # A GeoServer installation
-FROM openjdk:8-jre-slim
+FROM quay.io/azavea/geoserver:2.11.2-tomcat9-jre8-slim
 
-ENV GEOSERVER_VERSION 2.11.2
-ENV GEOSERVER_ZIP_URL https://s3.amazonaws.com/district-builder-global-artifacts-us-east-1/deps/geoserver-${GEOSERVER_VERSION}-bin.zip
-
-ENV GEOSERVER_DIR /usr/share
-ENV GEOSERVER_EXT_DIR $GEOSERVER_DIR/geoserver-$GEOSERVER_VERSION/webapps/geoserver/WEB-INF/lib
-ENV PATH /usr/share/geoserver-$GEOSERVER_VERSION/bin:$PATH
-ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
-ENV GEOSERVER_HOME $GEOSERVER_DIR/geoserver-$GEOSERVER_VERSION/
-
-RUN apt-get update && \
-  apt-get install -y -qq ca-certificates openssl unzip wget curl && \
-  update-ca-certificates && \
-  wget -O $GEOSERVER_DIR/geoserver.zip $GEOSERVER_ZIP_URL && \
-  unzip -qq $GEOSERVER_DIR/geoserver.zip -d $GEOSERVER_DIR && \
-  rm $GEOSERVER_DIR/geoserver.zip
-
-ENV GEOSERVER_DATA_DIR /data
-
-VOLUME $GEOSERVER_DATA_DIR
-
-COPY ./jetty.xml $GEOSERVER_DIR/etc/jetty.xml
-COPY ./geoserver-startup.sh $GEOSERVER_HOME/bin/geoserver-startup.sh
-COPY ./change_admin_password.sh $GEOSERVER_HOME/bin/change_admin_password.sh
-
-WORKDIR $GEOSERVER_HOME
-
-CMD ["sh", "bin/geoserver-startup.sh"]
+COPY ./change_admin_password.sh $CATALINA_HOME/bin/change_admin_password.sh

--- a/scripts/update
+++ b/scripts/update
@@ -52,7 +52,7 @@ function make_translations() {
 
 function change_geoserver_admin_password() {
     docker-compose \
-        exec -T geoserver ./bin/change_admin_password.sh
+        exec -T geoserver change_admin_password.sh
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]


### PR DESCRIPTION
## Overview

This PR replaces our GeoServer installation with an Azavea base image. This should simplify our build process and allow us to focus on configuring the GeoServer, rather than configuration _and_ installation.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Files changed in the PR have been `yapf`-ed for style violations~

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

I removed the relative path for `change_admin_password.sh`  in `scripts/update` because `${CATALINA_HOME}/bin` is on the GeoServer image `PATH`.


## Testing Instructions

 * Rebuild the GeoServer using the base image
 * Reconfigure the GeoServer using Django management commands
 * Interact with the app at [http://localhost:8080](http://localhost:8080) and ensure that the styling for map tiles is correct.
* Make sure you can sign into the GeoServer UI at http://localhost:8080/geoserver, and ensure you can see the `pmp` workspace.

```bash
$ ./scripts/update
$ ./scripts/configure_pa_data

# visit http://localhost:8080/geoserver and login to view workspaces, OR
# Pull MAP_SERVER_ADMIN_PASSWORD from .env, and use it in the 
# command below:
$ curl -XGET http://localhost:8080/geoserver/rest/workspaces/pmp.xml \
        -u admin:${MAP_SERVER_ADMIN_PASSWORD}
        -H "Accept: text/xml"
```
