### PR TITLE
Increase number of Gunicorn workers in Production

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -26,14 +26,13 @@ services:
       - /opt/district-builder/user-data/config_settings.py:/usr/src/app/publicmapping/config_settings.py
       - /opt/district-builder/user-data/config.xml:/usr/src/app/config/config.xml
     command:
-      - "--workers=2"
+      - "--workers=5"
       - "--timeout=60"
       - "--bind=0.0.0.0:${WEB_APP_PORT}"
       - "--log-level=info"
       - "--access-logfile=-"
       - "--error-logfile=-"
       - "--timeout=300"
-      - "-kgevent"
       - "publicmapping.wsgi"
     links:
       - xray:${XRAY_DAEMON_HOST}


### PR DESCRIPTION
## Overview

Bump the number of Gunicorn workers in production. Additionally, use the default worker type instead of `gevent`. 

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Files changed in the PR have been `yapf`-ed for style violations

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * Once the build passes & deploys to staging, see https://staging.pa.districtbuilder.azavea.com

Closes #124 
