### PR TITLE
Add link to plan view in submission report

### DIFF
--- a/django/publicmapping/redistricting/management/commands/submission_report.py
+++ b/django/publicmapping/redistricting/management/commands/submission_report.py
@@ -1,10 +1,12 @@
 import os.path
 import codecs
 
+from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.management.base import BaseCommand
 from django.core import serializers
 from django.template import loader
+from django.urls import reverse
 from django.utils import translation
 
 from redistricting.models import ScorePanel, PlanSubmission
@@ -45,6 +47,10 @@ class Command(BaseCommand):
         leaflet_css = staticfiles_storage.open('leaflet/leaflet.css').read()
         leaflet_js = staticfiles_storage.open('leaflet/leaflet.js').read()
         context = dict(
+            plan_url='https://{host}{path}'.format(
+                host=settings.ALLOWED_HOSTS[0],
+                path=reverse('plan-view', args=[submission.plan_id])
+            ),
             submission=submission,
             scores_html=scores_html,
             leaflet_css=leaflet_css,

--- a/django/publicmapping/redistricting/templates/submission_summary.html
+++ b/django/publicmapping/redistricting/templates/submission_summary.html
@@ -33,7 +33,7 @@
     <h2>Submission Details</h2>
     <div class="region">Region: {{ submission.region }}</div>
     <div class="division">Division: {{ submission.get_contest_division_display }}</div>
-    <div class="plan-name">Map name: {{ submission.submitted_plan_name }}</div>
+    <div class="plan-name">Map name: <a href="{{ plan_url }}" target="_blank">{{ submission.submitted_plan_name }}</a></div>
     <div class="contestant-name">Contestant name: {{ submission.first_name }} {{ submission.last_name }}</div>
     <div class="contestant-email">Email: {{ submission.email_address }}</div>
     <div class="map-values">Prioritized Values: {{ submission.values_choices }}</div>


### PR DESCRIPTION
## Overview

Adds a link to the submission report that directs the user to a plan's View page.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] ~Files changed in the PR have been `yapf`-ed for style violations~

### Demo

![dtl-link](https://user-images.githubusercontent.com/447977/48726130-698e0080-ebfc-11e8-87cb-39abc5d29c4e.png)

### Notes

- I made the map name into a link; we could also make it into a separate line and say something like "View submitted map on map.drawthelinespa.org". @tgilcrest let me know what you think. 

## Testing Instructions

 * Assuming you have a submission already, run `./scripts/server` inside the VM and then in a separate shell `docker-compose exec django bash`.
 * Run `./manage.py submission_report 1` (or some other submission ID)
 * Once it finishes, `vagrant rsync-back` and then view the HTML file in a browser. Confirm that the map name is now a link.
 * If you click the link, it won't work, because there's not really a good way for Django to know what protocol and port are in use when running outside the request / response cycle, so I set it to use `https` and port 80, which don't work on our local environments. However, you should be able to change the protocol to `http` and add port `:8080` and it'll direct you to your local instance.
 * However, it still won't completely work because the plan isn't shared. So run `./manage.py shell_plus`
 * `p = Plan.objects.get(pk=<ID from the URL>)`
 * `p.is_shared = True`
 * `p.save()`
 * Then reload and it should show the read-only page for the plan.

Closes #161985880
