### PR TITLE
One-off management command to reconfigure new legislative body #162929140

### DIFF
--- a/django/publicmapping/redistricting/management/commands/reconfigure_legislative_body_17_districts.py
+++ b/django/publicmapping/redistricting/management/commands/reconfigure_legislative_body_17_districts.py
@@ -1,0 +1,47 @@
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+import subprocess
+
+from redistricting.models import ComputedDistrictScore, Plan, ScoreFunction, Subject
+
+
+class Command(BaseCommand):
+    """
+    A one-off command to reconfigure the app to accomodate new config for
+    a second legislative body with 17 districts (while still preserving all
+    templates and plans).
+    """
+    help = 'Reconfigure for legislative body with 17 districts'
+
+    def handle(self, *args, **options):
+        """
+        Performs the steps
+        """
+        print('Reconfiguring for legislative body with 17 districts...')
+        remove_score_config()
+        download_pa_17_shapefile()
+        configure_templates()
+        print('Reconfiguration complete!')
+
+def remove_score_config():
+    """
+    Call removescoreconfig management command
+    """
+    print('Calling removecoreconfig...')
+    subprocess.check_call('./manage.py removescoreconfig', shell=True)
+
+def download_pa_17_shapefile():
+    """
+    Fetches the shapefile and unzips it. This is because data is not persisted in the container.
+    """
+    print('Fetching and unzipping shapefile')
+    subprocess.check_call('wget -q -O /data/districtbuilder_data.zip http://s3.amazonaws.com/global-districtbuilder-data-us-east-1/pa/pa_3785_w_17.zip', shell=True)
+    subprocess.check_call('unzip -o /data/districtbuilder_data.zip -d /data', shell=True)
+
+def configure_templates():
+    """
+    Configure templates
+    """
+    print('Configure templates')
+    subprocess.check_call('./manage.py setup config/config.xml -t', shell=True)


### PR DESCRIPTION
## Overview

Add a one-off management command to reconfigure new legislative body which has 17 districts.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

## Testing Instructions

* Check out commit 1bfcf69 (before change to add new legislative body was committed)
* Run `./scripts/configure_pa_data`
* Add a test plan called `foo`
* Check out this branch
* `./scripts/server`
* `docker-compose exec django bash` and then `./manage.py reconfigure_legislative_body_17_districts`
* Restart server
* Check and make sure the appropriate templates are available for both legislative bodies and that `foo` plan is still there and that you can edit the plan 

Closes #162929140
