### PR TITLE
Order legislative bodies by number of districts #163120488

### DIFF
--- a/django/publicmapping/redistricting/views.py
+++ b/django/publicmapping/redistricting/views.py
@@ -551,8 +551,7 @@ def commonplan(request, planid):
     long_label = body_member_long_label.strip().lower()
 
     has_regions = Region.objects.all().count() > 1
-    bodies = LegislativeBody.objects.all().order_by('region__sort_key',
-                                                    'sort_key')
+    bodies = LegislativeBody.objects.all().order_by('max_districts')
     l_bodies = [
         b for b in bodies
         if b in [


### PR DESCRIPTION
## Overview

Order legislative bodies by number of districts.

This is to ensure that the legislative body with 17 districts shows up first (default) in dropdown.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

### Notes

Legislative bodies were being sorted by region (both were in the same region) and then by order key (both had the same order key of 1 for my local instance). It seems that sort order was then based on some other arbitrary factor which in at least one case resulted in the 18 district map showing up first.

## Testing Instructions

* Restart server and go to select a map page
* Verify that the new legislative body with 17 districts shows up first in the dropdown

Closes #163120488
