### PR TITLE
Change text on the button that opens the submission form

### DIFF
--- a/django/publicmapping/redistricting/templates/editplan.html
+++ b/django/publicmapping/redistricting/templates/editplan.html
@@ -163,7 +163,7 @@
                     <p>When you’re ready, submit your map to the Draw the Lines contest here.</p>
                     <p>(NOTE: Once you press Submit on the form, your submission to the contest is final and can't be changed.  But you can continue to play around with your map!)</p>
                 </div>
-                <button id="btnEmailPlan" class="{% if not plan.is_valid %}hiddenelem{% endif %}">Submit</button>
+                <button id="btnEmailPlan" class="{% if not plan.is_valid %}hiddenelem{% endif %}">Take me to the submission form</button>
             </div>
         </div>
         <div id="sharepageright">


### PR DESCRIPTION
## Overview

Change text on the button that opens the submission form from "Submit" to "Take me to the submission form".

### Checklist

- [ ] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Go to a valid plan's "Submit" tab. Verify and see that this button has the correct text.

Closes [#162930005](https://www.pivotaltracker.com/story/show/162930005)
