### PR TITLE
Update districts labels and colors

### DIFF
--- a/django/publicmapping/publicmapping/templates/account.html
+++ b/django/publicmapping/publicmapping/templates/account.html
@@ -62,6 +62,9 @@
                 {% endif %}/></td>
             </tr>
             <tr>
+                <td colspan="2"><span class="recommended">Type N/A if not applicable.</span></td>
+            </tr>
+            <tr>
                 <td class="fname">{% trans "Organization/School" %} *</td>
                 <td><input id="organization" name="organization" class="field required" maxlength="30"
                 {% if is_registered %}

--- a/django/publicmapping/publicmapping/templates/account.html
+++ b/django/publicmapping/publicmapping/templates/account.html
@@ -62,7 +62,7 @@
                 {% endif %}/></td>
             </tr>
             <tr>
-                <td colspan="2"><span class="recommended">Type N/A if not applicable.</span></td>
+                <td colspan="2"><span class="recommended">Please enter your organization or school name. Type N/A if not applicable.</span></td>
             </tr>
             <tr>
                 <td class="fname">{% trans "Organization/School" %} *</td>

--- a/django/publicmapping/static/js/mapping.js
+++ b/django/publicmapping/static/js/mapping.js
@@ -2517,11 +2517,47 @@ function mapinit(srs,maxExtent) {
             });
         }
 
+        var getDistrictLabelRules = function() {
+            districts = [
+                { id:1, name:'District 1'},
+                { id:2, name:'District 2'},
+                { id:3, name:'District 3'},
+                { id:4, name:'District 4'},
+                { id:5, name:'District 5'},
+                { id:6, name:'District 6'},
+                { id:7, name:'District 7'},
+                { id:8, name:'District 8'},
+                { id:9, name:'District 9'},
+                { id:10, name:'District 10'},
+                { id:11, name:'District 11'},
+                { id:12, name:'District 12'},
+                { id:13, name:'District 13'},
+                { id:14, name:'District 14'},
+                { id:15, name:'District 15'},
+                { id:16, name:'District 16'},
+                { id:17, name:'District 17'},
+                { id:18, name:'District 18'},
+            ];
+
+            return districts.map(function(d) {
+                return new OpenLayers.Rule({
+                    filter: new OpenLayers.Filter.Function({
+                        evaluate: function(feature) {
+                            return feature.district_id === d.id;
+                        }
+                    }),
+                    symbolizer: {
+                        label: d.name.substring(9)
+                    }
+                });
+            });
+        }
+
         var callbackDistrict = function(sld) {
             var userStyle = getDefaultStyle(sld,getDistrictBy().name);
             var newStyle = new OpenLayers.Style(districtStyle, {
                 title: userStyle.title,
-                rules: userStyle.rules.concat(getDistrictShadingRules()).concat(getLockedRules())
+                rules: userStyle.rules.concat(getDistrictShadingRules()).concat(getLockedRules()).concat(getDistrictLabelRules())
             });
             $('#map').trigger('style_changed', [newStyle, districtLayer.name]);
          };
@@ -2671,7 +2707,7 @@ function mapinit(srs,maxExtent) {
                 var newOptions = OpenLayers.Util.extend({}, districtStyle);
                 var newStyle = new OpenLayers.Style(newOptions,{
                     title:'Districts',
-                    rules: getDistrictShadingRules().concat(getLockedRules())
+                    rules: getDistrictShadingRules().concat(getLockedRules()).concat(getDistrictLabelRules())
                 });
                 $('#map').trigger('style_changed', [newStyle, districtLayer.name]);
                 return;

--- a/django/publicmapping/static/js/mapping.js
+++ b/django/publicmapping/static/js/mapping.js
@@ -616,7 +616,7 @@ function mapinit(srs,maxExtent) {
         strokeWidth: 2,
         label: '${label}',
         fontColor: '#663300',
-        fontSize: '13pt',
+        fontSize: '12pt',
         fontFamily: 'Arial,Helvetica,sans-serif',
         fontWeight: '800',
         labelAlign: 'cm',

--- a/django/publicmapping/static/js/mapping.js
+++ b/django/publicmapping/static/js/mapping.js
@@ -2483,7 +2483,7 @@ function mapinit(srs,maxExtent) {
                 { id:2, name:'District 2', color: '#808000'},
                 { id:3, name:'District 3', color: '#aaffc3'},
                 { id:4, name:'District 4', color: '#800000'},
-                { id:5, name:'District 5', color: '#fffac8'},
+                { id:5, name:'District 5', color: '#e6194b'},
                 { id:6, name:'District 6', color: '#aa6e28'},
                 { id:7, name:'District 7', color: '#e6beff'},
                 { id:8, name:'District 8', color: '#008080'},
@@ -2496,7 +2496,7 @@ function mapinit(srs,maxExtent) {
                 { id:15, name:'District 15', color: '#0082c8'},
                 { id:16, name:'District 16', color: '#ffe119'},
                 { id:17, name:'District 17', color: '#3cb44b'},
-                { id:18, name:'District 18', color: '#e6194b'},
+                { id:18, name:'District 18', color: '#fffac8'},
             ];
 
             return districts.map(function(d) {

--- a/django/publicmapping/static/js/mapping.js
+++ b/django/publicmapping/static/js/mapping.js
@@ -616,7 +616,7 @@ function mapinit(srs,maxExtent) {
         strokeWidth: 2,
         label: '${label}',
         fontColor: '#663300',
-        fontSize: '10pt',
+        fontSize: '13pt',
         fontFamily: 'Arial,Helvetica,sans-serif',
         fontWeight: '800',
         labelAlign: 'cm',

--- a/django/publicmapping/static/js/mapping.js
+++ b/django/publicmapping/static/js/mapping.js
@@ -616,7 +616,7 @@ function mapinit(srs,maxExtent) {
         strokeWidth: 2,
         label: '${label}',
         fontColor: '#663300',
-        fontSize: '12pt',
+        fontSize: '13pt',
         fontFamily: 'Arial,Helvetica,sans-serif',
         fontWeight: '800',
         labelAlign: 'cm',


### PR DESCRIPTION
## Overview

Shorten district labels from "District xx" to just the number "xx". 
Swap colors of districts 5 and 18.
Increase label font size to 13pt.
(Also, add help text on signup form.)

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

<img width="1680" alt="screen shot 2019-01-29 at 3 01 10 pm" src="https://user-images.githubusercontent.com/3959096/51936931-4f7c5580-23d7-11e9-974e-fdfa43a24b7a.png">


## Testing Instructions

 * Serve and view a plan. Check that labels are shortened. 
 * District 5 should be a bright red color.
 * Font size should have increased from earlier.
 * On signup form, help text should show above Organization/School.

Closes [#162930055](https://www.pivotaltracker.com/story/show/162930055), [#163595004](https://www.pivotaltracker.com/story/show/163595004)
