### PR TITLE
Add Profile fields to User list and detail view in Admin panel

### DIFF
--- a/django/publicmapping/publicmapping/urls.py
+++ b/django/publicmapping/publicmapping/urls.py
@@ -51,6 +51,6 @@ urlpatterns = ([
     url(r'^comments/', include('django_comments.urls')),
     url(r'^proxy/', publicmapping_views.proxy),
     url(r'^session', publicmapping_views.session),
-    url(r'^admin', admin.site.urls),
+    url(r'^admin/', admin.site.urls),
     url(r'^i18n/', include('django.conf.urls.i18n'))
 ])

--- a/django/publicmapping/redistricting/admin.py
+++ b/django/publicmapping/redistricting/admin.py
@@ -27,10 +27,14 @@ License:
 Author:
     Andrew Jennings, David Zwarg
 """
+import json
+import inflect
+from functools import update_wrapper
 
-from models import *
-from forms import *
-from tasks import *
+import models
+from forms import SubjectUploadForm
+from tasks import reaggregate_plan, validate_plan, verify_count
+
 from django import forms
 from django.http import HttpResponse
 from django.contrib.gis import admin
@@ -40,9 +44,6 @@ from django.contrib.admin import helpers
 from django.utils.translation import ugettext_lazy, ugettext as _
 from django.core.exceptions import PermissionDenied
 from django import template
-from django.conf import settings
-import inflect
-from functools import update_wrapper
 
 
 class ComputedCharacteristicAdmin(admin.ModelAdmin):
@@ -89,7 +90,7 @@ class CharacteristicInline(admin.TabularInline):
     """
 
     # The model that this inline class is displaying.
-    model = Characteristic
+    model = models.Characteristic
 
 
 class GeounitAdmin(admin.OSMGeoAdmin):
@@ -140,7 +141,7 @@ class DistrictInline(admin.TabularInline):
     )
 
     # The model that this inline class is displaying.
-    model = District
+    model = models.District
 
 
 class DistrictAdmin(admin.OSMGeoAdmin):
@@ -212,7 +213,7 @@ class PlanAdmin(admin.ModelAdmin):
         for plan in queryset:
             # Set the reaggregating flag
             # (needed for the state to display on immediate refresh)
-            plan.processing_state = ProcessingState.REAGGREGATING
+            plan.processing_state = models.ProcessingState.REAGGREGATING
             plan.save()
 
             # Reaggregate asynchronously
@@ -379,7 +380,7 @@ class SubjectAdmin(admin.ModelAdmin):
         """
         opts = modeladmin.model._meta
         app_label = opts.app_label
-        geolevel, nunits = LegislativeLevel.get_basest_geolevel_and_count()
+        geolevel, nunits = models.LegislativeLevel.get_basest_geolevel_and_count()
         context = {
             # get geounits at the basest of all base geolevels
             'geounits':
@@ -545,7 +546,7 @@ class ScorePanelAdmin(admin.ModelAdmin):
 
 
 class ScoreArgumentInline(admin.TabularInline):
-    model = ScoreArgument
+    model = models.ScoreArgument
 
 
 class ScoreFunctionAdmin(admin.ModelAdmin):
@@ -614,22 +615,22 @@ class ValidationCriteriaAdmin(admin.ModelAdmin):
 
 
 # Register these classes with the admin interface.
-admin.site.register(Geounit, GeounitAdmin)
-admin.site.register(Region)
-admin.site.register(ComputedCharacteristic, ComputedCharacteristicAdmin)
-admin.site.register(Characteristic, CharacteristicAdmin)
-admin.site.register(Subject, SubjectAdmin)
-admin.site.register(Geolevel)
-admin.site.register(LegislativeBody)
-admin.site.register(LegislativeLevel)
-admin.site.register(Plan, PlanAdmin)
-admin.site.register(District, DistrictAdmin)
-admin.site.register(Profile)
-admin.site.register(ScoreArgument, ScoreArgumentAdmin)
-admin.site.register(ScoreDisplay, ScoreDisplayAdmin)
-admin.site.register(ScoreFunction, ScoreFunctionAdmin)
-admin.site.register(ScorePanel, ScorePanelAdmin)
-admin.site.register(ValidationCriteria, ValidationCriteriaAdmin)
-admin.site.register(ComputedDistrictScore)
-admin.site.register(ComputedPlanScore)
-admin.site.register(ContiguityOverride)
+admin.site.register(models.Geounit, GeounitAdmin)
+admin.site.register(models.Region)
+admin.site.register(models.ComputedCharacteristic, ComputedCharacteristicAdmin)
+admin.site.register(models.Characteristic, CharacteristicAdmin)
+admin.site.register(models.Subject, SubjectAdmin)
+admin.site.register(models.Geolevel)
+admin.site.register(models.LegislativeBody)
+admin.site.register(models.LegislativeLevel)
+admin.site.register(models.Plan, PlanAdmin)
+admin.site.register(models.District, DistrictAdmin)
+admin.site.register(models.Profile)
+admin.site.register(models.ScoreArgument, ScoreArgumentAdmin)
+admin.site.register(models.ScoreDisplay, ScoreDisplayAdmin)
+admin.site.register(models.ScoreFunction, ScoreFunctionAdmin)
+admin.site.register(models.ScorePanel, ScorePanelAdmin)
+admin.site.register(models.ValidationCriteria, ValidationCriteriaAdmin)
+admin.site.register(models.ComputedDistrictScore)
+admin.site.register(models.ComputedPlanScore)
+admin.site.register(models.ContiguityOverride)


### PR DESCRIPTION
## Overview
Exposes certain user profile fields like county and school/organization to both the user list and detail views.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

### Demo
<img width="940" alt="screen shot 2019-02-15 at 11 38 57 am" src="https://user-images.githubusercontent.com/1032849/52870661-5369e080-3116-11e9-975a-2ed02d363d6a.png">
<img width="829" alt="screen shot 2019-02-15 at 11 38 47 am" src="https://user-images.githubusercontent.com/1032849/52870668-55cc3a80-3116-11e9-9916-1235b423e55c.png">

## Notes
- Also fixes a minor issue where admin panel URL prefixes did not include a `/` after the `admin` portion of the URL, leading to URLs like `/adminauth/` and `/adminredistricting/`.

## Testing Instructions
- Load the User Admin list at http://localhost:8080/admin/auth/user/
  - The users should be listed with columns for profile org/school, county, division and social media handles
- Select a user and open the detail view
  - At the bottom should be a section with fields for the same values shown in the list view, plus two fields for the user's "How did you hear about us?" and "Where?" response

Closes [PT162929871](https://www.pivotaltracker.com/story/show/162929871)
