### PR TITLE
Add How and Where did you hear about us to the admin user list

### DIFF
--- a/django/publicmapping/redistricting/admin.py
+++ b/django/publicmapping/redistricting/admin.py
@@ -75,6 +75,8 @@ class CustomUserAdmin(UserAdmin):
             'get_county',
             'get_division',
             'get_social_media',
+            'get_how_did_you_hear',
+            'get_where_did_you_hear'
         ]
 
     def get_inline_instances(self, request, obj=None):
@@ -97,6 +99,14 @@ class CustomUserAdmin(UserAdmin):
     def get_social_media(self, user):
         return user.profile.social_media
     get_social_media.short_description = "Social media"
+
+    def get_how_did_you_hear(self, user):
+        return user.profile.how_did_you_hear
+    get_how_did_you_hear.short_description = "How did you hear?"
+
+    def get_where_did_you_hear(self, user):
+        return user.profile.where_did_you_hear
+    get_where_did_you_hear.short_description = "Where did you hear?"
 
 
 class ComputedCharacteristicAdmin(admin.ModelAdmin):


### PR DESCRIPTION
## Overview
To help the World Bank export data using the user list view, this adds the "How did you hear about us?" and "Where did you hear about us?" (Shortened to "How did you hear?" and "Where did you hear?" respectively) to the user list view.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [ ] Files changed in the PR have been `yapf`-ed for style violations

### Demo
![screen shot 2019-02-21 at 2 56 56 pm](https://user-images.githubusercontent.com/1032849/53197837-0cce2780-35e9-11e9-8549-a85e8c73e138.png)

## Testing Instructions
- Open the Admin panel and navigate to the User list view
 - You should see a column for "How did you hear?" and "Where did you hear?"

Closes [PT164139210](https://www.pivotaltracker.com/story/show/164139210)
