### PR TITLE
Update submission report for 17 district instance

### DIFF
--- a/django/publicmapping/redistricting/management/commands/submission_report.py
+++ b/django/publicmapping/redistricting/management/commands/submission_report.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
 
         template = loader.get_template('submission_summary.html')
         # We're going to reuse the summary panel from the main map editing page
-        score_panel = ScorePanel.objects.filter(name='plan_submission_summary')[0]
+        score_panel = ScorePanel.objects.filter(name='plan_submission_summary_17')[0]
         districts = [d for d in submission.plan.district_set.all() if not d.is_unassigned]
         # The above Score Display is split into two ScorePanels: the top summary panel and the
         # bottom panel of per-district scores. We want the summary panel.
@@ -48,7 +48,7 @@ class Command(BaseCommand):
         leaflet_js = staticfiles_storage.open('leaflet/leaflet.js').read()
         context = dict(
             plan_url='https://{host}{path}'.format(
-                host=settings.ALLOWED_HOSTS[0],
+                host='map.drawthelinespa.org',
                 path=reverse('plan-view', args=[submission.plan_id])
             ),
             submission=submission,

--- a/django/publicmapping/redistricting/templates/submission_summary.html
+++ b/django/publicmapping/redistricting/templates/submission_summary.html
@@ -68,11 +68,7 @@
     </script>
     <script type="text/javascript">
       var map = L.map('leaflet');
-      L.tileLayer(
-        'https://api.mapbox.com/styles/v1/tgilcrest/cjfx0n99k069t2rq8tw784u2h/tiles/256/' +
-        '{z}/{x}/{y}?access_token=' +
-        'pk.eyJ1IjoidGdpbGNyZXN0IiwiYSI6ImNqZnd6d2pqMzBqc2MzMm53MGgybWltOXAifQ.I2v96bMX7g-XPckWlDwJ5Q'
-      ).addTo(map);
+      L.tileLayer('https://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}').addTo(map);
       layer.addTo(map);
       map.fitBounds(layer.getBounds());
     </script>


### PR DESCRIPTION
## Overview

Minor changes to the submission report generation script to support the 17 district contest:
 * Point to the 17 district score panel
 * Hardcode the host, so we don't need to run sed command
 * Update map url to use ArcGIS basemap

### Checklist

- ~~[ ] PR has a name that won't get you publicly shamed for vagueness~~
- ~~[ ] Files changed in the PR have been `yapf`-ed for style violations~~

### Notes

I'm currently running this to export the contest submissions, and will merge when it's complete.

