### PR TITLE
Bump psycopg2 to 2.7.3.2

### DIFF
--- a/django/publicmapping/requirements.txt
+++ b/django/publicmapping/requirements.txt
@@ -3,7 +3,7 @@ dict2xml==1.5
 ipython==5.5.0
 gevent==1.2.2
 Django==1.11.10
-psycopg2==2.7.3
+psycopg2==2.7.3.2
 redis==2.10.6
 celery[redis]==4.1.0
 kombu==4.1.0

--- a/scripts/test
+++ b/scripts/test
@@ -27,7 +27,7 @@ then
     then
         usage
     else
-        if which shellcheck &>/dev/null; then
+        if command -v shellcheck; then
             echo "Linting STRTA scripts"
             find ./scripts -type f -print0 | xargs -0 -r shellcheck
         fi


### PR DESCRIPTION
## Overview

After scaling the Gunicorn workers to account for the temporary instance type bump, I ran `update` and `server` to cycle things.

The Gunicorn workers failed to start with an error like:

```bash
root@52b2562dcc48:/usr/src/app# python
Python 2.7.17 (default, Nov 23 2019, 07:36:52)
[GCC 8.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import psycopg2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/psycopg2/__init__.py", line 50, in <module>
    from psycopg2._psycopg import (                     # noqa
ImportError: /usr/local/lib/python2.7/site-packages/psycopg2/.libs/libresolv-2-c4c53def.5.so: symbol __res_maybe_init version GLIBC_PRIVATE not defined in file libc.so.6 with link time reference
```

It seems like this has been an issue for a [long time](https://github.com/psycopg/psycopg2-wheels/issues/2); the release that fixes it is over 2 years old. What's strange is we just [ran into it](https://github.com/OpenTreeMap/otm-core/pull/3274) on OTM as well. 

The only variable that's different here is I was building the container images on my local workstation, connected to the remote Docker engine, as opposed to on Travis. I don't _think_ this should make a difference since the Docker client simply tells the remote Docker engine to execute commands.

## Testing Instructions

`docker exec` into a container, in prod, and see that `import psycopg2` is successful:

```bash
[ec2-user@ip-10-0-0-217 ~]$ docker exec -it 234 bash
root@2342ac88a863:/usr/src/app# python
Python 2.7.17 (default, Nov 23 2019, 07:36:52)
[GCC 8.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import psycopg2
>>>
```

Interact with https://map.drawthelinespa.org.